### PR TITLE
Centralize configuration defaults and validation in KurtConfig

### DIFF
--- a/src/kurt/cli.py
+++ b/src/kurt/cli.py
@@ -18,7 +18,7 @@ from kurt.commands.project import project
 from kurt.commands.research import research
 from kurt.commands.status import status
 from kurt.commands.telemetry import telemetry
-from kurt.config import config_exists, create_config, get_config_file_path
+from kurt.config.base import KurtConfig, config_file_exists, create_config, get_config_file_path
 from kurt.db.database import init_database
 from kurt.telemetry.decorators import track_command
 
@@ -39,7 +39,7 @@ def main(ctx):
         return
 
     # Check if project is initialized
-    if not config_exists():
+    if not config_file_exists():
         return  # Let commands handle "not initialized" error
 
     # Check for pending migrations
@@ -83,23 +83,23 @@ def main(ctx):
 @main.command()
 @click.option(
     "--db-path",
-    default=".kurt/kurt.sqlite",
-    help="Path to database file relative to current directory (default: .kurt/kurt.sqlite)",
+    default=KurtConfig.DEFAULT_DB_PATH,
+    help=f"Path to database file relative to current directory (default: {KurtConfig.DEFAULT_DB_PATH})",
 )
 @click.option(
     "--sources-path",
-    default="sources",
-    help="Path to store fetched content relative to current directory (default: sources)",
+    default=KurtConfig.DEFAULT_SOURCES_PATH,
+    help=f"Path to store fetched content relative to current directory (default: {KurtConfig.DEFAULT_SOURCES_PATH})",
 )
 @click.option(
     "--projects-path",
-    default="projects",
-    help="Path to store project-specific content relative to current directory (default: projects)",
+    default=KurtConfig.DEFAULT_PROJECTS_PATH,
+    help=f"Path to store project-specific content relative to current directory (default: {KurtConfig.DEFAULT_PROJECTS_PATH})",
 )
 @click.option(
     "--rules-path",
-    default="rules",
-    help="Path to store rules and configurations relative to current directory (default: rules)",
+    default=KurtConfig.DEFAULT_RULES_PATH,
+    help=f"Path to store rules and configurations relative to current directory (default: {KurtConfig.DEFAULT_RULES_PATH})",
 )
 @track_command
 def init(db_path: str, sources_path: str, projects_path: str, rules_path: str):
@@ -120,7 +120,7 @@ def init(db_path: str, sources_path: str, projects_path: str, rules_path: str):
 
     try:
         # Check if already initialized
-        if config_exists():
+        if config_file_exists():
             config_file = get_config_file_path()
             console.print(f"[yellow]Kurt project already initialized ({config_file})[/yellow]")
             overwrite = console.input("Reinitialize? (y/N): ")

--- a/src/kurt/config/base.py
+++ b/src/kurt/config/base.py
@@ -1,0 +1,422 @@
+"""
+Kurt configuration management.
+
+Loads configuration from .kurt file in the current directory.
+This file stores project-specific settings like database path and project root.
+"""
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class KurtConfig(BaseModel):
+    """Kurt project configuration."""
+
+    # Configuration defaults and acceptable values (ClassVar to avoid treating as fields)
+    DEFAULT_DB_PATH: ClassVar[str] = ".kurt/kurt.sqlite"
+    DEFAULT_SOURCES_PATH: ClassVar[str] = "sources"
+    DEFAULT_PROJECTS_PATH: ClassVar[str] = "projects"
+    DEFAULT_RULES_PATH: ClassVar[str] = "rules"
+    DEFAULT_INDEXING_LLM_MODEL: ClassVar[str] = "openai/gpt-4o-mini"
+    DEFAULT_FETCH_ENGINE: ClassVar[str] = "trafilatura"
+
+    # Acceptable values for validation
+    VALID_FETCH_ENGINES: ClassVar[list[str]] = ["trafilatura", "firecrawl"]
+
+    # Common DSPy LLM providers (for reference/validation - not exhaustive)
+    # DSPy uses format: "provider/model-name"
+    # Examples: "openai/gpt-4o-mini", "anthropic/claude-3-sonnet", "google/gemini-1.5-pro"
+    # Note: DSPy doesn't export an official list - it's extensible and supports any LiteLLM-compatible provider
+    # This list is maintained manually based on common providers
+    KNOWN_LLM_PROVIDERS: ClassVar[list[str]] = [
+        "openai",
+        "anthropic",
+        "google",
+        "cohere",
+        "together",
+        "anyscale",
+        "databricks",
+        "groq",
+        "azure",
+        "bedrock",
+        "vertex",
+        "ollama",
+    ]
+
+    @classmethod
+    def validate_llm_model_format(cls, model: str) -> tuple[bool, str]:
+        """Validate LLM model format and return (is_valid, message).
+
+        Args:
+            model: Model string to validate (e.g., "openai/gpt-4o-mini")
+
+        Returns:
+            Tuple of (is_valid, message) where message explains any issues
+        """
+        if not model:
+            return False, "INDEXING_LLM_MODEL is empty"
+
+        if "/" not in model:
+            return False, f"INDEXING_LLM_MODEL should be in format 'provider/model': {model}"
+
+        provider, model_name = model.split("/", 1)
+        if not provider or not model_name:
+            return False, f"Invalid format: {model}"
+
+        # Warning if using unknown provider (not an error - DSPy is extensible)
+        if provider not in cls.KNOWN_LLM_PROVIDERS:
+            return (
+                True,
+                f"Using provider '{provider}' (not in common list). "
+                f"Known providers: {', '.join(cls.KNOWN_LLM_PROVIDERS[:5])}...",
+            )
+
+        return True, ""
+
+    PATH_DB: str = Field(
+        default=DEFAULT_DB_PATH,
+        description="Path to the SQLite database file (relative to kurt.config location)",
+    )
+    PATH_SOURCES: str = Field(
+        default=DEFAULT_SOURCES_PATH,
+        description="Path to store fetched content (relative to kurt.config location)",
+    )
+    PATH_PROJECTS: str = Field(
+        default=DEFAULT_PROJECTS_PATH,
+        description="Path to store project-specific content (relative to kurt.config location)",
+    )
+    PATH_RULES: str = Field(
+        default=DEFAULT_RULES_PATH,
+        description="Path to store rules and configurations (relative to kurt.config location)",
+    )
+    INDEXING_LLM_MODEL: str = Field(
+        default=DEFAULT_INDEXING_LLM_MODEL,
+        description="LLM model for indexing documents (metadata extraction, classification)",
+    )
+    INGESTION_FETCH_ENGINE: str = Field(
+        default=DEFAULT_FETCH_ENGINE,
+        description="Fetch engine for content ingestion: 'firecrawl' or 'trafilatura'",
+    )
+    # Telemetry configuration
+    TELEMETRY_ENABLED: bool = Field(
+        default=True,
+        description="Enable telemetry collection (can be disabled via DO_NOT_TRACK or KURT_TELEMETRY_DISABLED env vars)",
+    )
+
+    # Analytics provider configurations (stored as extra fields with ANALYTICS_ prefix)
+    # CMS provider configurations (stored as extra fields with CMS_ prefix)
+    # These are dynamically added when onboarding providers
+    # Example: ANALYTICS_POSTHOG_PROJECT_ID, CMS_SANITY_PROD_PROJECT_ID
+    model_config = {"extra": "allow"}  # Pydantic v2: Allow additional fields
+
+    @field_validator("TELEMETRY_ENABLED", mode="before")
+    @classmethod
+    def validate_telemetry_enabled(cls, v: Any) -> bool:
+        """
+        Convert various string representations to boolean.
+
+        Truthy values: "true", "1", "yes", "on" (case-insensitive)
+        Falsy values: "false", "0", "no", "off", or any other string
+        """
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            return v.lower() in ("true", "1", "yes", "on")
+        # For any other type, convert to bool
+        return bool(v)
+
+    def _get_project_root(self) -> Path:
+        """Get project root directory (where kurt.config is located) - internal use."""
+        return get_config_file_path().parent
+
+    def get_absolute_db_path(self) -> Path:
+        """Get absolute path to database file."""
+        project_root = self._get_project_root()
+        db_path = Path(self.PATH_DB)
+
+        # If DB path is relative, resolve it relative to project root
+        if not db_path.is_absolute():
+            return project_root / db_path
+        return db_path
+
+    def get_db_directory(self) -> Path:
+        """Get the .kurt directory path."""
+        return self.get_absolute_db_path().parent
+
+    def get_absolute_sources_path(self) -> Path:
+        """Get absolute path to sources content directory."""
+        project_root = self._get_project_root()
+        sources_path = Path(self.PATH_SOURCES)
+
+        # If sources path is relative, resolve it relative to project root
+        if not sources_path.is_absolute():
+            return project_root / sources_path
+        return sources_path
+
+    def get_absolute_projects_path(self) -> Path:
+        """Get absolute path to projects directory."""
+        project_root = self._get_project_root()
+        projects_path = Path(self.PATH_PROJECTS)
+
+        # If projects path is relative, resolve it relative to project root
+        if not projects_path.is_absolute():
+            return project_root / projects_path
+        return projects_path
+
+    def get_absolute_rules_path(self) -> Path:
+        """Get absolute path to rules directory."""
+        project_root = self._get_project_root()
+        rules_path = Path(self.PATH_RULES)
+
+        # If rules path is relative, resolve it relative to project root
+        if not rules_path.is_absolute():
+            return project_root / rules_path
+        return rules_path
+
+
+def get_config_file_path() -> Path:
+    """Get the path to the kurt configuration file."""
+    return Path.cwd() / "kurt.config"
+
+
+def load_config() -> KurtConfig:
+    """
+    Load Kurt configuration from kurt.config file in current directory.
+
+    The kurt.config file should contain key=value pairs:
+
+    KURT_PROJECT_PATH=.
+    KURT_DB=.kurt/kurt.sqlite
+    source_path=sources
+
+    Returns:
+        KurtConfig with loaded settings
+
+    Raises:
+        FileNotFoundError: If kurt.config file doesn't exist
+        ValueError: If configuration is invalid
+    """
+    config_file = get_config_file_path()
+
+    if not config_file.exists():
+        raise FileNotFoundError(
+            f"Kurt configuration file not found: {config_file}\n"
+            "Run 'kurt init' to initialize a Kurt project."
+        )
+
+    # Parse config file
+    config_data = {}
+    with open(config_file, "r") as f:
+        for line in f:
+            line = line.strip()
+            # Skip empty lines and comments
+            if not line or line.startswith("#"):
+                continue
+
+            # Parse key=value
+            if "=" in line:
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip().strip('"').strip("'")  # Remove quotes
+                config_data[key] = value
+
+    # Pydantic will handle type validation via field_validator
+    return KurtConfig(**config_data)
+
+
+def create_config(
+    db_path: str = KurtConfig.DEFAULT_DB_PATH,
+    sources_path: str = KurtConfig.DEFAULT_SOURCES_PATH,
+    projects_path: str = KurtConfig.DEFAULT_PROJECTS_PATH,
+    rules_path: str = KurtConfig.DEFAULT_RULES_PATH,
+) -> KurtConfig:
+    """
+    Create a new kurt.config configuration file in the current directory.
+
+    The project root is determined by the location of kurt.config.
+
+    Args:
+        db_path: Path to the SQLite database (relative to kurt.config location)
+        sources_path: Path to store fetched content (relative to kurt.config location)
+        projects_path: Path to store project-specific content (relative to kurt.config location)
+        rules_path: Path to store rules and configurations (relative to kurt.config location)
+
+    Returns:
+        KurtConfig instance
+    """
+    config = KurtConfig(
+        PATH_DB=db_path,
+        PATH_SOURCES=sources_path,
+        PATH_PROJECTS=projects_path,
+        PATH_RULES=rules_path,
+    )
+
+    config_file = get_config_file_path()
+
+    # Ensure parent directory exists (though it should be cwd)
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write config file
+    with open(config_file, "w") as f:
+        f.write("# Kurt Project Configuration\n")
+        f.write("# This file is auto-generated by 'kurt init'\n\n")
+        f.write(f'PATH_DB="{config.PATH_DB}"\n')
+        f.write(f'PATH_SOURCES="{config.PATH_SOURCES}"\n')
+        f.write(f'PATH_PROJECTS="{config.PATH_PROJECTS}"\n')
+        f.write(f'PATH_RULES="{config.PATH_RULES}"\n')
+        f.write(f'INDEXING_LLM_MODEL="{config.INDEXING_LLM_MODEL}"\n')
+        f.write(f'INGESTION_FETCH_ENGINE="{config.INGESTION_FETCH_ENGINE}"\n')
+        f.write("\n# Telemetry Configuration\n")
+        # Write boolean as True/False (not "True"/"False" string)
+        f.write(f'TELEMETRY_ENABLED={config.TELEMETRY_ENABLED}\n')
+
+    return config
+
+
+def config_file_exists() -> bool:
+    """Check if kurt.config configuration file exists."""
+    return get_config_file_path().exists()
+
+
+# Backwards compatibility alias
+def config_exists() -> bool:
+    """
+    Deprecated: Use config_file_exists() instead.
+    Check if kurt.config configuration file exists.
+    """
+    return config_file_exists()
+
+
+def get_config_or_default() -> KurtConfig:
+    """
+    Get configuration, or return default if kurt.config file doesn't exist.
+
+    Returns:
+        KurtConfig with loaded or default settings
+    """
+    if config_file_exists():
+        return load_config()
+    else:
+        # Return default config (without creating file)
+        return KurtConfig()
+
+
+def update_config(config: KurtConfig) -> None:
+    """
+    Update the kurt.config file with new configuration values.
+
+    Args:
+        config: KurtConfig instance to save
+    """
+    config_file = get_config_file_path()
+
+    # Write updated config
+    with open(config_file, "w") as f:
+        f.write("# Kurt Project Configuration\n")
+        f.write("# This file is auto-generated by 'kurt init'\n\n")
+        f.write(f'PATH_DB="{config.PATH_DB}"\n')
+        f.write(f'PATH_SOURCES="{config.PATH_SOURCES}"\n')
+        f.write(f'PATH_PROJECTS="{config.PATH_PROJECTS}"\n')
+        f.write(f'PATH_RULES="{config.PATH_RULES}"\n')
+        f.write(f'INDEXING_LLM_MODEL="{config.INDEXING_LLM_MODEL}"\n')
+        f.write(f'INGESTION_FETCH_ENGINE="{config.INGESTION_FETCH_ENGINE}"\n')
+        f.write("\n# Telemetry Configuration\n")
+        # Write boolean as True/False (not "True"/"False" string)
+        f.write(f'TELEMETRY_ENABLED={config.TELEMETRY_ENABLED}\n')
+
+        # Write extra fields (analytics, CMS, etc.) - Pydantic v2 stores extra fields in __pydantic_extra__
+        extra_fields = getattr(config, '__pydantic_extra__', {})
+
+        # Group extra fields by prefix (ANALYTICS_, CMS_, RESEARCH_, etc.)
+        # This allows any integration to store config in the main file
+        prefixes = {}
+        for key, value in extra_fields.items():
+            # Extract prefix (e.g., "ANALYTICS" from "ANALYTICS_POSTHOG_API_KEY")
+            if "_" in key:
+                prefix = key.split("_")[0]
+                if prefix not in prefixes:
+                    prefixes[prefix] = {}
+                prefixes[prefix][key] = value
+
+        # Write each prefix group with a header
+        prefix_names = {
+            "ANALYTICS": "Analytics Provider Configurations",
+            "CMS": "CMS Provider Configurations",
+            "RESEARCH": "Research Provider Configurations",
+        }
+
+        for prefix in sorted(prefixes.keys()):
+            header = prefix_names.get(prefix, f"{prefix} Configurations")
+            f.write(f"\n# {header}\n")
+            for key, value in sorted(prefixes[prefix].items()):
+                f.write(f'{key}="{value}"\n')
+
+
+def validate_config(config: KurtConfig) -> list[str]:
+    """
+    Validate configuration and return list of warnings/errors.
+
+    Args:
+        config: KurtConfig instance to validate
+
+    Returns:
+        List of validation issues (empty if all valid)
+
+    Example:
+        >>> config = load_config()
+        >>> issues = validate_config(config)
+        >>> if issues:
+        ...     for issue in issues:
+        ...         print(f"Warning: {issue}")
+    """
+    issues = []
+
+    # Check if DB directory exists
+    db_path = config.get_absolute_db_path()
+    db_dir = db_path.parent
+    if not db_dir.exists():
+        issues.append(
+            f"Database directory does not exist: {db_dir}\n"
+            f"Create it with: mkdir -p {db_dir}"
+        )
+
+    # Check if sources directory exists
+    sources_path = config.get_absolute_sources_path()
+    if not sources_path.exists():
+        issues.append(
+            f"Sources directory does not exist: {sources_path}\n"
+            f"Create it with: mkdir -p {sources_path}"
+        )
+
+    # Check if projects directory exists
+    projects_path = config.get_absolute_projects_path()
+    if not projects_path.exists():
+        issues.append(
+            f"Projects directory does not exist: {projects_path}\n"
+            f"Create it with: mkdir -p {projects_path}"
+        )
+
+    # Check if rules directory exists
+    rules_path = config.get_absolute_rules_path()
+    if not rules_path.exists():
+        issues.append(
+            f"Rules directory does not exist: {rules_path}\n"
+            f"Create it with: mkdir -p {rules_path}"
+        )
+
+    # Validate LLM model format
+    is_valid, message = KurtConfig.validate_llm_model_format(config.INDEXING_LLM_MODEL)
+    if not is_valid:
+        issues.append(message)
+    elif message:  # Warning message
+        issues.append(f"Warning: {message}")
+
+    # Validate fetch engine
+    if config.INGESTION_FETCH_ENGINE not in KurtConfig.VALID_FETCH_ENGINES:
+        issues.append(
+            f"INGESTION_FETCH_ENGINE must be one of {KurtConfig.VALID_FETCH_ENGINES}, got: {config.INGESTION_FETCH_ENGINE}"
+        )
+
+    return issues

--- a/src/kurt/content/fetch.py
+++ b/src/kurt/content/fetch.py
@@ -1,0 +1,808 @@
+"""
+Content fetching and storage functions for Kurt.
+
+This module handles downloading and storing document content:
+- Fetching content from URLs using Firecrawl or Trafilatura
+- Extracting metadata (title, author, dates, description)
+- Storing content as markdown files
+- Batch async fetching for performance
+
+Fetch Engine Selection:
+- If FIRECRAWL_API_KEY is set in environment → use Firecrawl
+- Otherwise → use Trafilatura (fallback)
+
+Key Functions:
+- add_document: Create document record (NOT_FETCHED status)
+- fetch_document: Download and store content for a document
+- fetch_documents_batch: Async batch fetch for multiple documents
+"""
+
+import asyncio
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+from uuid import UUID
+
+import trafilatura
+from dotenv import find_dotenv, load_dotenv
+
+from kurt.config import KurtConfig, load_config
+from kurt.db.database import get_session
+from kurt.db.models import Document, IngestionStatus, SourceType
+
+# Load environment variables from .env file
+# Search from current working directory upwards
+dotenv_path = find_dotenv(usecwd=True)
+if dotenv_path:
+    load_dotenv(dotenv_path, override=False)
+else:
+    # If no .env found from cwd, try the default search (from module location)
+    load_dotenv(override=False)
+
+
+def _get_fetch_engine(override: str = None) -> str:
+    """
+    Determine which fetch engine to use based on configuration and API key availability.
+
+    Priority:
+    1. If override is specified → use override (if valid)
+    2. If INGESTION_FETCH_ENGINE is 'firecrawl' AND FIRECRAWL_API_KEY is set → use Firecrawl
+    3. Otherwise → use Trafilatura (fallback)
+
+    Args:
+        override: Optional engine override ('firecrawl' or 'trafilatura')
+
+    Returns:
+        'firecrawl' if configured and API key available, otherwise 'trafilatura'
+    """
+    # Handle override
+    if override:
+        override = override.lower()
+        if override not in KurtConfig.VALID_FETCH_ENGINES:
+            raise ValueError(
+                f"Invalid fetch engine: {override}. Must be one of {KurtConfig.VALID_FETCH_ENGINES}"
+            )
+
+        # Validate Firecrawl API key if using Firecrawl
+        if override == "firecrawl":
+            firecrawl_api_key = os.getenv("FIRECRAWL_API_KEY")
+            if not firecrawl_api_key or firecrawl_api_key == "your_firecrawl_api_key_here":
+                raise ValueError(
+                    "Cannot use Firecrawl: FIRECRAWL_API_KEY not set or invalid.\n"
+                    f"Add your API key to .env file or use --fetch-engine={KurtConfig.VALID_FETCH_ENGINES[0]}"
+                )
+        return override
+
+    # Use config default
+    try:
+        config = load_config()
+        default_engine = config.INGESTION_FETCH_ENGINE.lower()
+    except Exception:
+        # If config fails to load, use default from KurtConfig
+        default_engine = KurtConfig.DEFAULT_FETCH_ENGINE
+
+    # Check if Firecrawl is requested
+    if default_engine == "firecrawl":
+        firecrawl_api_key = os.getenv("FIRECRAWL_API_KEY")
+
+        # Verify API key is set and valid (not a placeholder)
+        if firecrawl_api_key and firecrawl_api_key != "your_firecrawl_api_key_here":
+            return "firecrawl"
+
+    # Default to trafilatura
+    return KurtConfig.DEFAULT_FETCH_ENGINE
+
+
+def _fetch_with_firecrawl(url: str) -> tuple[str, dict]:
+    """
+    Fetch content using Firecrawl API.
+
+    Args:
+        url: URL to fetch
+
+    Returns:
+        Tuple of (content_markdown, metadata_dict)
+
+    Raises:
+        Exception: If fetch fails
+    """
+    from firecrawl import FirecrawlApp
+
+    api_key = os.getenv("FIRECRAWL_API_KEY")
+    if not api_key:
+        raise ValueError("[Firecrawl] FIRECRAWL_API_KEY not set in environment")
+
+    try:
+        app = FirecrawlApp(api_key=api_key)
+        # Scrape the URL and get markdown using the v2 API
+        result = app.scrape(url, formats=["markdown", "html"])
+    except Exception as e:
+        raise ValueError(f"[Firecrawl] API error: {type(e).__name__}: {str(e)}") from e
+
+    if not result or not hasattr(result, "markdown"):
+        raise ValueError(f"[Firecrawl] No content extracted from: {url}")
+
+    content = result.markdown
+
+    # Extract metadata from Firecrawl response
+    metadata = {}
+    if hasattr(result, "metadata") and result.metadata:
+        metadata = result.metadata if isinstance(result.metadata, dict) else {}
+
+    return content, metadata
+
+
+def _fetch_with_trafilatura(url: str) -> tuple[str, dict]:
+    """
+    Fetch content using Trafilatura.
+
+    Args:
+        url: URL to fetch
+
+    Returns:
+        Tuple of (content_markdown, metadata_dict)
+
+    Raises:
+        ValueError: If fetch fails
+    """
+    # Download content
+    try:
+        downloaded = trafilatura.fetch_url(url)
+        if not downloaded:
+            raise ValueError(f"[Trafilatura] Failed to download (no content returned): {url}")
+    except Exception as e:
+        raise ValueError(f"[Trafilatura] Download error: {type(e).__name__}: {str(e)}") from e
+
+    # Extract metadata using trafilatura
+    metadata = trafilatura.extract_metadata(
+        downloaded,
+        default_url=url,
+        extensive=True,  # More comprehensive metadata extraction
+    )
+
+    # Extract content as markdown
+    content = trafilatura.extract(
+        downloaded,
+        output_format="markdown",
+        include_tables=True,
+        include_links=True,
+        url=url,  # Helps with metadata extraction
+        with_metadata=True,  # Include metadata in extraction
+    )
+
+    if not content:
+        raise ValueError(
+            f"[Trafilatura] No content extracted (page might be empty or paywall blocked): {url}"
+        )
+
+    # Convert trafilatura metadata to dict
+    metadata_dict = {}
+    if metadata:
+        metadata_dict = {
+            "title": metadata.title,
+            "author": metadata.author,
+            "date": metadata.date,
+            "description": metadata.description,
+            "fingerprint": metadata.fingerprint,
+        }
+
+    return content, metadata_dict
+
+
+def _detect_source_type(source_url: str) -> tuple[str, dict]:
+    """
+    Detect if source URL is web (http/https) or CMS (platform/instance/schema/slug).
+
+    Args:
+        source_url: Source URL or CMS identifier
+
+    Returns:
+        Tuple of (source_type, parsed_data):
+            - source_type: 'web' or 'cms'
+            - parsed_data: For web: {'url': url}, For CMS: {'platform': ..., 'instance': ..., 'schema': ..., 'slug': ...}
+
+    Example:
+        >>> _detect_source_type("https://example.com/page")
+        ('web', {'url': 'https://example.com/page'})
+
+        >>> _detect_source_type("sanity/prod/article/vibe-coding-guide")
+        ('cms', {'platform': 'sanity', 'instance': 'prod', 'schema': 'article', 'slug': 'vibe-coding-guide'})
+    """
+    if source_url.startswith(('http://', 'https://')):
+        return 'web', {'url': source_url}
+
+    # Assume CMS format: platform/instance/schema/slug
+    parts = source_url.split('/', 3)
+    if len(parts) == 4:
+        return 'cms', {
+            'platform': parts[0],
+            'instance': parts[1],
+            'schema': parts[2],
+            'slug': parts[3]
+        }
+
+    # Also support legacy 3-part format for backward compatibility
+    if len(parts) == 3:
+        return 'cms', {
+            'platform': parts[0],
+            'instance': parts[1],
+            'schema': None,
+            'slug': parts[2]
+        }
+
+    raise ValueError(
+        f"Invalid source URL format: {source_url}. "
+        f"Expected either http(s):// URL or platform/instance/schema/slug format"
+    )
+
+
+def _create_cms_content_path(platform: str, instance: str, doc_id: str, config: KurtConfig) -> Path:
+    """
+    Create filesystem path for CMS content.
+
+    Args:
+        platform: CMS platform name (sanity, contentful, etc)
+        instance: Instance name (prod, staging, etc)
+        doc_id: Document ID
+        config: Kurt configuration
+
+    Returns:
+        Path object for content file
+
+    Example:
+        >>> _create_cms_content_path("sanity", "prod", "abc-123", config)
+        Path("sources/cms/sanity/prod/abc-123.md")
+    """
+    source_base = config.get_absolute_sources_path()
+    content_path = source_base / "cms" / platform / instance / f"{doc_id}.md"
+    return content_path
+
+
+def _create_content_path(url: str, config: KurtConfig) -> Path:
+    """
+    Create filesystem path for storing content.
+
+    Format: {source_path}/{domain}/{subdomain}/{path}/page_name.md
+
+    Example:
+        url: https://docs.example.com/guide/getting-started
+        → sources/docs.example.com/guide/getting-started.md
+
+        url: https://example.com/
+        → sources/example.com/index.md
+
+        url: https://www.example.com/
+        → sources/example.com/index.md (www stripped for consistency)
+    """
+    parsed = urlparse(url)
+
+    # Get domain (netloc includes port if present)
+    domain = parsed.netloc or "unknown"
+
+    # Normalize domain: strip 'www.' prefix for consistency
+    # This ensures www.getdbt.com and getdbt.com map to the same folder
+    if domain.startswith("www."):
+        domain = domain[4:]  # Remove "www."
+
+    # Get path components
+    path = parsed.path.strip("/")
+
+    # If empty path, use 'index'
+    if not path:
+        path = "index"
+
+    # If path ends with /, append 'index'
+    if path.endswith("/"):
+        path = path + "index"
+
+    # Add .md extension if not present
+    if not path.endswith(".md"):
+        path = path + ".md"
+
+    # Build full path: source_path/domain/path
+    source_base = config.get_absolute_sources_path()
+    content_path = source_base / domain / path
+
+    return content_path
+
+
+def _fetch_from_cms(platform: str, instance: str, doc: Document) -> tuple[str, dict]:
+    """
+    Fetch content from CMS using appropriate adapter.
+
+    Args:
+        platform: CMS platform name
+        instance: Instance name
+        doc: Document object (must have cms_document_id field populated)
+
+    Returns:
+        Tuple of (markdown_content, metadata_dict)
+
+    Raises:
+        ValueError: If CMS fetch fails or cms_document_id is missing
+    """
+    from kurt.cms import get_adapter
+    from kurt.cms.config import get_platform_config
+
+    # Validate cms_document_id is present
+    if not doc.cms_document_id:
+        raise ValueError(
+            f"Document {doc.id} is missing cms_document_id field. "
+            f"This field is required to fetch from CMS. "
+            f"Document may have been created before cms_document_id migration."
+        )
+
+    try:
+        # Get CMS adapter
+        cms_config = get_platform_config(platform, instance)
+        adapter = get_adapter(platform, cms_config)
+
+        # Fetch document using CMS document ID (not the slug)
+        cms_document = adapter.fetch(doc.cms_document_id)
+
+        # Extract metadata
+        metadata_dict = {
+            'title': cms_document.title,
+            'author': cms_document.author,
+            'date': cms_document.published_date,
+            'description': cms_document.metadata.get('description') if cms_document.metadata else None,
+        }
+
+        return cms_document.content, metadata_dict
+
+    except Exception as e:
+        raise ValueError(f"Failed to fetch from {platform}/{instance} (cms_document_id: {doc.cms_document_id}): {e}")
+
+
+def add_document(url: str, title: str = None) -> UUID:
+    """
+    Create document record with NOT_FETCHED status.
+
+    If document with URL already exists, returns existing document ID.
+
+    Args:
+        url: Source URL
+        title: Optional title (defaults to last path segment)
+
+    Returns:
+        UUID of created or existing document
+
+    Example:
+        doc_id = add_document("https://example.com/page1", "Page 1")
+        # Returns: UUID('550e8400-e29b-41d4-a716-446655440000')
+    """
+    from sqlmodel import select
+
+    session = get_session()
+
+    # Check if document already exists
+    stmt = select(Document).where(Document.source_url == url)
+    existing_doc = session.exec(stmt).first()
+
+    if existing_doc:
+        return existing_doc.id
+
+    # Generate title from URL if not provided
+    if not title:
+        title = url.rstrip("/").split("/")[-1] or url
+
+    # Create document
+    doc = Document(
+        title=title,
+        source_type=SourceType.URL,
+        source_url=url,
+        ingestion_status=IngestionStatus.NOT_FETCHED,
+    )
+
+    session.add(doc)
+    session.commit()
+    session.refresh(doc)
+
+    return doc.id
+
+
+def fetch_document(identifier: str | UUID, fetch_engine: str = None) -> dict:
+    """
+    Fetch content for document (by ID or URL).
+
+    If identifier is a URL and document doesn't exist, creates it first.
+    Downloads content using the specified fetch engine or config default.
+
+    Args:
+        identifier: Document UUID (as string or UUID object) or source URL
+        fetch_engine: Optional engine override ('firecrawl' or 'trafilatura')
+
+    Returns:
+        dict with keys:
+            - document_id: UUID
+            - title: str
+            - content_length: int
+            - status: str ('FETCHED' or 'ERROR')
+
+    Raises:
+        ValueError: If document not found or download fails
+
+    Example:
+        # Fetch by ID (string)
+        result = fetch_document("550e8400-e29b-41d4-a716-446655440000")
+
+        # Fetch by ID (UUID object)
+        result = fetch_document(UUID("550e8400-e29b-41d4-a716-446655440000"))
+
+        # Fetch by URL (creates if doesn't exist)
+        result = fetch_document("https://example.com/page1")
+
+        # Fetch using specific engine
+        result = fetch_document("https://example.com/page1", fetch_engine="firecrawl")
+
+        # Returns: {'document_id': UUID(...), 'title': 'Page 1', ...}
+    """
+    from sqlmodel import select
+
+    session = get_session()
+    doc = None
+
+    # Try to find document
+    try:
+        # If already a UUID object, use it directly; otherwise try to parse as UUID
+        if isinstance(identifier, UUID):
+            doc_id = identifier
+        else:
+            doc_id = UUID(identifier)
+
+        doc = session.get(Document, doc_id)
+        if not doc:
+            raise ValueError(f"Document not found: {identifier}")
+
+    except (ValueError, AttributeError):
+        # Not a UUID, treat as URL
+        stmt = select(Document).where(Document.source_url == identifier)
+        doc = session.exec(stmt).first()
+
+        if not doc:
+            # Create new document for this URL
+            doc_id = add_document(str(identifier))
+            doc = session.get(Document, doc_id)
+
+    # Update status to indicate we're fetching
+    doc.ingestion_status = IngestionStatus.FETCHED  # Will set to ERROR if fails
+
+    try:
+        # Detect source type (web vs CMS)
+        source_type, parsed_data = _detect_source_type(doc.source_url)
+
+        if source_type == 'cms':
+            # Fetch from CMS using cms_document_id field
+            content, metadata_dict = _fetch_from_cms(
+                platform=parsed_data['platform'],
+                instance=parsed_data['instance'],
+                doc=doc
+            )
+        else:
+            # Fetch from web using appropriate engine
+            engine = _get_fetch_engine(override=fetch_engine)
+
+            if engine == "firecrawl":
+                content, metadata_dict = _fetch_with_firecrawl(doc.source_url)
+            else:
+                content, metadata_dict = _fetch_with_trafilatura(doc.source_url)
+
+        # Update document with extracted metadata
+        if metadata_dict:
+            # Title (prefer metadata title over URL-derived title)
+            if metadata_dict.get("title"):
+                doc.title = metadata_dict["title"]
+
+            # Content hash (fingerprint for deduplication)
+            if metadata_dict.get("fingerprint"):
+                doc.content_hash = metadata_dict["fingerprint"]
+
+            # Description
+            if metadata_dict.get("description"):
+                doc.description = metadata_dict["description"]
+
+            # Author(s) - convert to list if single author
+            author = metadata_dict.get("author")
+            if author:
+                if isinstance(author, str):
+                    doc.author = [author]
+                else:
+                    doc.author = list(author) if author else None
+
+            # Published date
+            date_str = metadata_dict.get("date")
+            if date_str:
+                # metadata.date is a string in YYYY-MM-DD format
+                from datetime import datetime
+
+                try:
+                    doc.published_date = datetime.fromisoformat(date_str)
+                except (ValueError, AttributeError):
+                    # If parsing fails, store as None
+                    doc.published_date = None
+
+        # Store content to filesystem
+        config = load_config()
+
+        # Choose path based on source type
+        if source_type == 'cms':
+            # CMS: sources/cms/{platform}/{instance}/{cms_document_id}.md
+            content_path = _create_cms_content_path(
+                platform=parsed_data['platform'],
+                instance=parsed_data['instance'],
+                doc_id=doc.cms_document_id,
+                config=config
+            )
+        else:
+            # Web: sources/{domain}/{path}/page_name.md
+            content_path = _create_content_path(doc.source_url, config)
+
+        # Create directory structure
+        content_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write markdown content
+        with open(content_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        # Store relative path in document
+        source_base = config.get_absolute_sources_path()
+        doc.content_path = str(content_path.relative_to(source_base))
+        doc.ingestion_status = IngestionStatus.FETCHED
+
+        session.commit()
+
+        return {
+            "document_id": doc.id,
+            "title": doc.title,
+            "content_length": len(content),
+            "status": "FETCHED",
+            "content_path": str(content_path),
+            "content": content,  # Return content for immediate use
+            # Metadata fields
+            "content_hash": doc.content_hash,
+            "description": doc.description,
+            "author": doc.author,
+            "published_date": doc.published_date,
+        }
+
+    except Exception as e:
+        # Mark as ERROR
+        doc.ingestion_status = IngestionStatus.ERROR
+        session.commit()
+        raise e
+
+
+async def _fetch_one_async(
+    doc_id: str, semaphore: asyncio.Semaphore, fetch_engine: str = None
+) -> dict:
+    """Fetch single document with concurrency control."""
+    async with semaphore:
+        try:
+            # Run sync fetch_document in executor to avoid blocking
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(None, fetch_document, doc_id, fetch_engine)
+            return {"success": True, **result}
+        except Exception as e:
+            return {
+                "success": False,
+                "document_id": doc_id,
+                "error": str(e),
+            }
+
+
+def fetch_documents_batch(
+    document_ids: list[str],
+    max_concurrent: int = 5,
+    fetch_engine: str = None,
+) -> list[dict]:
+    """
+    Fetch multiple documents in parallel using async HTTP.
+
+    Args:
+        document_ids: List of document UUIDs or URLs to fetch
+        max_concurrent: Maximum number of concurrent downloads (default: 5)
+        fetch_engine: Optional engine override ('firecrawl' or 'trafilatura')
+
+    Returns:
+        List of results, one per document:
+            - success: bool
+            - document_id: UUID
+            - title: str (if success)
+            - content_length: int (if success)
+            - error: str (if failed)
+
+    Example:
+        # Fetch all NOT_FETCHED documents from a URL
+        results = fetch_documents_batch([
+            "550e8400-e29b-41d4-a716-446655440000",
+            "660e9500-f30c-52e5-b827-557766551111",
+        ], max_concurrent=10)
+
+        # Fetch using specific engine
+        results = fetch_documents_batch(doc_ids, fetch_engine="firecrawl")
+
+        # Check results
+        successful = [r for r in results if r["success"]]
+        failed = [r for r in results if not r["success"]]
+    """
+    # Show warning if using Trafilatura for large batch
+    engine = _get_fetch_engine(override=fetch_engine)
+    if engine == "trafilatura" and len(document_ids) > 10:
+        print("\n⚠️  Warning: Fetching large volumes with Trafilatura may encounter rate limits.")
+        print("   For better reliability with large batches, consider using Firecrawl:")
+        print('   1. Update kurt.config: INGESTION_FETCH_ENGINE="firecrawl"')
+        print("   2. Add FIRECRAWL_API_KEY to your .env file")
+        print("   Get your API key at: https://firecrawl.dev\n")
+
+    async def _batch_fetch():
+        semaphore = asyncio.Semaphore(max_concurrent)
+        tasks = [_fetch_one_async(doc_id, semaphore, fetch_engine) for doc_id in document_ids]
+        return await asyncio.gather(*tasks)
+
+    return asyncio.run(_batch_fetch())
+
+
+def fetch_content(
+    include_pattern: str = None,
+    urls: str = None,
+    ids: str = None,
+    in_cluster: str = None,
+    with_status: str = None,
+    with_content_type: str = None,
+    exclude: str = None,
+    limit: int = None,
+    concurrency: int = 5,
+    engine: str = None,
+    skip_index: bool = False,
+    refetch: bool = False,
+) -> dict:
+    """
+    High-level fetch function with filtering, validation, and orchestration.
+
+    This function handles all the business logic for fetching documents:
+    - Filter selection and validation
+    - Database query building
+    - Glob pattern matching
+    - Document count warnings
+    - Batch fetching orchestration
+
+    Args:
+        include_pattern: Glob pattern matching source_url or content_path
+        urls: Comma-separated list of source URLs
+        ids: Comma-separated list of document IDs
+        in_cluster: Cluster name to fetch from
+        with_status: Status filter (NOT_FETCHED | FETCHED | ERROR)
+        with_content_type: Content type filter (tutorial | guide | blog | etc)
+        exclude: Glob pattern to exclude
+        limit: Max documents to process
+        concurrency: Parallel requests (default: 5)
+        engine: Fetch engine (trafilatura | firecrawl)
+        skip_index: Skip LLM indexing
+        refetch: Include already FETCHED documents
+
+    Returns:
+        dict with:
+            - docs: List of Document objects to fetch
+            - doc_ids: List of document IDs
+            - total: Total count
+            - warnings: List of warning messages
+            - errors: List of error messages
+
+    Raises:
+        ValueError: If no filter is provided or invalid parameters
+    """
+    from fnmatch import fnmatch
+
+    from sqlmodel import select
+
+    from kurt.db.database import get_session
+    from kurt.db.models import Document, IngestionStatus
+
+    # Validate: at least one filter required
+    if not (include_pattern or urls or ids or in_cluster or with_status or with_content_type):
+        raise ValueError(
+            "Requires at least ONE filter: --include, --urls, --ids, --in-cluster, --with-status, or --with-content-type"
+        )
+
+    warnings = []
+    errors = []
+
+    session = get_session()
+
+    # Build query based on filters
+    stmt = select(Document)
+
+    # Filter by IDs
+    if ids:
+        from uuid import UUID
+
+        doc_ids = [UUID(id.strip()) for id in ids.split(",")]
+        stmt = stmt.where(Document.id.in_(doc_ids))
+
+    # Filter by URLs
+    if urls:
+        url_list = [url.strip() for url in urls.split(",")]
+        stmt = stmt.where(Document.source_url.in_(url_list))
+
+    # Filter by cluster (JOIN with edges and clusters tables)
+    if in_cluster:
+        from kurt.db.models import DocumentClusterEdge, TopicCluster
+
+        stmt = (
+            stmt.join(DocumentClusterEdge, Document.id == DocumentClusterEdge.document_id)
+            .join(TopicCluster, DocumentClusterEdge.cluster_id == TopicCluster.id)
+            .where(TopicCluster.name.ilike(f"%{in_cluster}%"))
+        )
+
+    # Filter by content type
+    if with_content_type:
+        from kurt.db.models import ContentType
+
+        try:
+            content_type_enum = ContentType(with_content_type.lower())
+            stmt = stmt.where(Document.content_type == content_type_enum)
+        except ValueError:
+            raise ValueError(
+                f"Invalid content type: {with_content_type}. "
+                f"Valid types: {', '.join([ct.value for ct in ContentType])}"
+            )
+
+    # Count total documents before status filter (to track excluded FETCHED docs)
+    docs_before_status_filter = list(session.exec(stmt).all())
+
+    # Filter by status (default: exclude FETCHED unless --refetch or --with-status FETCHED)
+    if with_status:
+        stmt = stmt.where(Document.ingestion_status == IngestionStatus[with_status])
+    elif not refetch:
+        # Default: exclude FETCHED documents
+        stmt = stmt.where(Document.ingestion_status != IngestionStatus.FETCHED)
+
+    docs = list(session.exec(stmt).all())
+
+    # Apply include/exclude patterns (glob matching on source_url or content_path)
+    if include_pattern:
+        docs = [
+            d
+            for d in docs
+            if (d.source_url and fnmatch(d.source_url, include_pattern))
+            or (d.content_path and fnmatch(d.content_path, include_pattern))
+        ]
+
+    if exclude:
+        docs = [
+            d
+            for d in docs
+            if not (
+                (d.source_url and fnmatch(d.source_url, exclude))
+                or (d.content_path and fnmatch(d.content_path, exclude))
+            )
+        ]
+
+    # Apply limit
+    if limit:
+        docs = docs[:limit]
+
+    # Warn if >100 docs
+    if len(docs) > 100:
+        warnings.append(f"About to fetch {len(docs)} documents")
+
+    # Calculate estimated cost
+    estimated_cost = len(docs) * 0.005 if not skip_index else 0
+
+    # Count excluded FETCHED documents (only if we applied the default filter)
+    excluded_fetched_count = 0
+    if not with_status and not refetch:
+        fetched_docs = [
+            d for d in docs_before_status_filter if d.ingestion_status == IngestionStatus.FETCHED
+        ]
+        excluded_fetched_count = len(fetched_docs)
+
+    return {
+        "docs": docs,
+        "doc_ids": [str(doc.id) for doc in docs],
+        "total": len(docs),
+        "warnings": warnings,
+        "errors": errors,
+        "estimated_cost": estimated_cost,
+        "excluded_fetched_count": excluded_fetched_count,
+    }

--- a/src/kurt/content/map.py
+++ b/src/kurt/content/map.py
@@ -1,0 +1,1652 @@
+"""
+URL discovery and mapping functions for Kurt.
+
+This module handles discovering URLs from various sources:
+- Sitemaps (sitemap.xml files)
+- Blogroll pages (blog indexes, release notes, changelogs)
+- LLM-powered extraction of chronological content
+
+Key Functions:
+- map_sitemap: Discover URLs from sitemap
+- map_blogrolls: Discover URLs from blogroll/changelog pages (with dates)
+- identify_blogroll_candidates: Find potential blogroll pages from sitemap URLs
+- extract_chronological_content: LLM-powered extraction of posts from HTML pages
+"""
+
+import logging
+import re
+from datetime import datetime
+from fnmatch import fnmatch
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+import dspy
+import httpx
+import trafilatura
+from dspy import ChainOfThought, Signature
+from pydantic import BaseModel, Field
+
+from kurt.config import KurtConfig
+from kurt.db.database import get_session
+from kurt.db.models import Document, IngestionStatus, SourceType
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_url(url: str) -> str:
+    """
+    Normalize URL by removing anchors and query strings.
+
+    This prevents duplicate documents from being created for URLs that
+    only differ by anchor or query parameters.
+
+    Args:
+        url: URL to normalize
+
+    Returns:
+        Normalized URL without anchor or query string
+
+    Example:
+        >>> normalize_url("https://example.com/blog?page=1#latest")
+        "https://example.com/blog"
+        >>> normalize_url("https://example.com/blog")
+        "https://example.com/blog"
+    """
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(url)
+    # Remove fragment (anchor) and query string
+    normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+    return normalized
+
+
+# ============================================================================
+# Sitemap Discovery
+# ============================================================================
+
+
+def _discover_sitemap_urls(base_url: str) -> list[str]:
+    """
+    Discover sitemap URLs using httpx (reliable fetching).
+
+    Workflow:
+    1. Check robots.txt for sitemap location
+    2. Try common sitemap URLs (/sitemap.xml, /sitemap_index.xml)
+    3. Parse sitemap XML to extract URLs
+
+    Args:
+        base_url: Base URL to search for sitemaps
+
+    Returns:
+        List of URLs found in sitemap(s)
+
+    Raises:
+        ValueError: If no sitemap found or accessible
+    """
+    import xml.etree.ElementTree as ET
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+
+    sitemap_urls = []
+
+    # Step 1: Check robots.txt
+    try:
+        response = httpx.get(f"{base}/robots.txt", timeout=10.0, follow_redirects=True)
+        if response.status_code == 200:
+            for line in response.text.split("\n"):
+                if line.lower().startswith("sitemap:"):
+                    sitemap_url = line.split(":", 1)[1].strip()
+                    sitemap_urls.append(sitemap_url)
+    except Exception:
+        pass  # robots.txt not found or not accessible
+
+    # Step 2: Try common sitemap locations
+    common_paths = ["/sitemap.xml", "/sitemap_index.xml", "/sitemap-index.xml"]
+    for path in common_paths:
+        if f"{base}{path}" not in sitemap_urls:
+            sitemap_urls.append(f"{base}{path}")
+
+    # Step 3: Fetch and parse sitemaps
+    all_urls = []
+
+    for sitemap_url in sitemap_urls:
+        try:
+            response = httpx.get(sitemap_url, timeout=30.0, follow_redirects=True)
+            if response.status_code != 200:
+                continue
+
+            # Parse XML
+            root = ET.fromstring(response.content)
+
+            # Check if it's a sitemap index (contains <sitemap> tags)
+            sitemaps = root.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}sitemap")
+            if sitemaps:
+                # It's a sitemap index - recursively fetch child sitemaps
+                for sitemap in sitemaps:
+                    loc = sitemap.find("{http://www.sitemaps.org/schemas/sitemap/0.9}loc")
+                    if loc is not None and loc.text:
+                        child_sitemap_url = loc.text.strip()
+                        try:
+                            child_response = httpx.get(
+                                child_sitemap_url, timeout=30.0, follow_redirects=True
+                            )
+                            if child_response.status_code == 200:
+                                child_root = ET.fromstring(child_response.content)
+                                urls = child_root.findall(
+                                    ".//{http://www.sitemaps.org/schemas/sitemap/0.9}url"
+                                )
+                                for url_elem in urls:
+                                    loc_elem = url_elem.find(
+                                        "{http://www.sitemaps.org/schemas/sitemap/0.9}loc"
+                                    )
+                                    if loc_elem is not None and loc_elem.text:
+                                        all_urls.append(loc_elem.text.strip())
+                        except Exception:
+                            continue
+            else:
+                # It's a regular sitemap - extract URLs
+                urls = root.findall(".//{http://www.sitemaps.org/schemas/sitemap/0.9}url")
+                for url_elem in urls:
+                    loc = url_elem.find("{http://www.sitemaps.org/schemas/sitemap/0.9}loc")
+                    if loc is not None and loc.text:
+                        all_urls.append(loc.text.strip())
+
+            # If we found URLs, we're done
+            if all_urls:
+                return all_urls
+
+        except Exception:
+            continue  # Try next sitemap URL
+
+    # No sitemap found
+    if not all_urls:
+        raise ValueError(f"No sitemap found for {base_url}")
+
+    return all_urls
+
+
+def crawl_website(
+    homepage: str,
+    max_depth: int = 2,
+    max_pages: int = 100,
+    allow_external: bool = False,
+    include_patterns: tuple = (),
+    exclude_patterns: tuple = (),
+) -> list[str]:
+    """
+    Crawl a website using trafilatura's focused_crawler.
+
+    This is used as a fallback when no sitemap is found or when explicit
+    crawling is requested with --max-depth.
+
+    Args:
+        homepage: Starting URL for crawl
+        max_depth: Maximum crawl depth (approximate - trafilatura uses max_seen_urls)
+        max_pages: Maximum number of pages to discover
+        allow_external: If True, follow external links (outside domain)
+        include_patterns: Include URL patterns (glob)
+        exclude_patterns: Exclude URL patterns (glob)
+
+    Returns:
+        List of discovered URLs (strings)
+
+    Note:
+        - Trafilatura's focused_crawler doesn't have explicit depth control,
+          so we use max_seen_urls as a proxy for depth
+        - The crawler automatically respects robots.txt
+        - Navigation pages (archives, categories) are prioritized
+    """
+    from fnmatch import fnmatch
+    from urllib.parse import urlparse
+
+    from trafilatura.spider import focused_crawler
+
+    # Convert max_depth to max_seen_urls
+    # Depth 1 = ~10 URLs, Depth 2 = ~50 URLs, Depth 3+ = ~100+ URLs
+    depth_to_urls = {
+        1: 10,
+        2: 50,
+        3: 100,
+    }
+    max_seen_urls = depth_to_urls.get(max_depth, max_depth * 50) if max_depth else 100
+    max_seen_urls = min(max_seen_urls, max_pages)  # Respect max_pages limit
+
+    logger.info(f"Crawling {homepage} with max_seen_urls={max_seen_urls} (depth={max_depth})")
+
+    # Run focused crawler
+    to_visit, known_links = focused_crawler(
+        homepage=homepage,
+        max_seen_urls=max_seen_urls,
+        max_known_urls=max_pages,
+    )
+
+    # Convert to list
+    all_urls = list(known_links)
+
+    # Filter external links if not allowed
+    if not allow_external:
+        homepage_domain = urlparse(homepage).netloc
+        filtered_urls = []
+        for url in all_urls:
+            url_domain = urlparse(url).netloc
+            if url_domain == homepage_domain:
+                filtered_urls.append(url)
+        all_urls = filtered_urls
+        logger.info(f"Filtered to {len(all_urls)} internal URLs (allow_external=False)")
+
+    # Apply include/exclude patterns
+    if include_patterns:
+        filtered = []
+        for url in all_urls:
+            if any(fnmatch(url, pattern) for pattern in include_patterns):
+                filtered.append(url)
+        all_urls = filtered
+        logger.info(f"Applied include patterns: {len(all_urls)} URLs match")
+
+    if exclude_patterns:
+        filtered = []
+        for url in all_urls:
+            if not any(fnmatch(url, pattern) for pattern in exclude_patterns):
+                filtered.append(url)
+        all_urls = filtered
+        logger.info(f"Applied exclude patterns: {len(all_urls)} URLs remain")
+
+    # Apply final limit
+    if len(all_urls) > max_pages:
+        all_urls = all_urls[:max_pages]
+        logger.info(f"Limited to {max_pages} URLs")
+
+    logger.info(f"Crawling discovered {len(all_urls)} URLs")
+    return all_urls
+
+
+def map_sitemap(
+    url: str,
+    fetch_all: bool = False,
+    limit: int = None,
+    discover_blogrolls: bool = False,
+    max_blogrolls: int = 10,
+    llm_model: str = KurtConfig.DEFAULT_INDEXING_LLM_MODEL,
+    include_patterns: tuple = (),
+    exclude_patterns: tuple = (),
+) -> list[dict]:
+    """
+    Discover sitemap and create documents in database with NOT_FETCHED status.
+
+    Uses trafilatura's sitemap_search() which handles:
+    - Common sitemap locations (/sitemap.xml, etc.)
+    - Sitemap indexes (nested sitemaps)
+    - robots.txt parsing
+    - URL normalization
+
+    Args:
+        url: Base URL or specific sitemap URL
+        fetch_all: If True, fetch content for all documents immediately
+        limit: Maximum number of URLs to process (creates + fetches only this many)
+        discover_blogrolls: If True, also discover posts from blogroll/changelog pages
+        max_blogrolls: Maximum number of blogroll pages to scrape (if discover_blogrolls=True)
+        llm_model: LLM model to use for blogroll extraction
+
+    Returns:
+        List of created documents with keys:
+            - document_id: UUID
+            - url: str
+            - title: str
+            - status: str ('NOT_FETCHED' or 'FETCHED' if fetch_all=True)
+            - is_chronological: bool (only if discovered from blogroll)
+            - discovery_method: str (only if discovered from blogroll)
+
+    Raises:
+        ValueError: If no sitemap found
+
+    Example:
+        # Basic sitemap mapping
+        docs = map_sitemap("https://example.com")
+
+        # With blogroll discovery
+        docs = map_sitemap("https://example.com", discover_blogrolls=True)
+        # Returns sitemap docs + additional posts found on blogroll pages
+    """
+    from sqlmodel import select
+
+    # Import fetch functions here to avoid circular imports
+    from kurt.content.fetch import fetch_document
+
+    # Use custom sitemap discovery (more reliable than trafilatura)
+    urls = _discover_sitemap_urls(url)
+
+    # Apply filters
+    from fnmatch import fnmatch
+
+    if include_patterns:
+        filtered = []
+        for discovered_url in urls:
+            if any(fnmatch(discovered_url, pattern) for pattern in include_patterns):
+                filtered.append(discovered_url)
+        urls = filtered
+
+    if exclude_patterns:
+        filtered = []
+        for discovered_url in urls:
+            if not any(fnmatch(discovered_url, pattern) for pattern in exclude_patterns):
+                filtered.append(discovered_url)
+        urls = filtered
+
+    # Apply limit to URL processing
+    if limit:
+        urls = list(urls)[:limit]
+
+    session = get_session()
+    created_docs = []
+
+    for discovered_url in urls:
+        # Check if document already exists
+        stmt = select(Document).where(Document.source_url == discovered_url)
+        existing_doc = session.exec(stmt).first()
+
+        if existing_doc:
+            # Skip if already exists
+            created_docs.append(
+                {
+                    "document_id": existing_doc.id,
+                    "url": existing_doc.source_url,
+                    "title": existing_doc.title,
+                    "status": existing_doc.ingestion_status.value,
+                    "created": False,
+                    "fetched": False,
+                }
+            )
+            continue
+
+        # Generate title from URL
+        title = discovered_url.rstrip("/").split("/")[-1] or discovered_url
+
+        # Create document
+        doc = Document(
+            title=title,
+            source_type=SourceType.URL,
+            source_url=discovered_url,
+            ingestion_status=IngestionStatus.NOT_FETCHED,
+            discovery_method="sitemap",
+            discovery_url=url,  # The sitemap URL
+        )
+
+        session.add(doc)
+        session.commit()
+        session.refresh(doc)
+
+        doc_result = {
+            "document_id": doc.id,
+            "url": doc.source_url,
+            "title": doc.title,
+            "status": doc.ingestion_status.value,
+            "created": True,
+            "fetched": False,
+        }
+
+        # Fetch content if requested
+        if fetch_all:
+            try:
+                fetch_result = fetch_document(str(doc.id))
+                doc_result["status"] = fetch_result["status"]
+                doc_result["fetched"] = True
+                doc_result["content_length"] = fetch_result["content_length"]
+            except Exception as e:
+                # Continue on fetch errors
+                doc_result["fetch_error"] = str(e)
+
+        created_docs.append(doc_result)
+
+    # Optionally discover additional posts from blogroll/changelog pages
+    if discover_blogrolls:
+        print("\n--- Discovering blogroll/changelog pages ---")
+        sitemap_urls = [doc["url"] for doc in created_docs]
+        blogroll_docs = map_blogrolls(
+            sitemap_urls,
+            llm_model=llm_model,
+            max_blogrolls=max_blogrolls,
+        )
+        created_docs.extend(blogroll_docs)
+
+    return created_docs
+
+
+# ============================================================================
+# Blogroll and Chronological Content Discovery
+# ============================================================================
+
+# Common URL patterns for chronological content
+BLOGROLL_PATTERNS = [
+    "/blog",
+    "/blog/",
+    "/news",
+    "/news/",
+    "/releases",
+    "/releases/",
+    "/release-notes",
+    "/release-notes/",
+    "/changelog",
+    "/changelog/",
+    "/updates",
+    "/updates/",
+    "/announcements",
+    "/announcements/",
+    "/articles",
+    "/articles/",
+    "/dbt-versions/",
+]
+
+# Category-level blogroll patterns
+CATEGORY_PATTERNS = [
+    "/blog/category/",
+    "/blog/categories/",
+    "/category/",
+    "/categories/",
+    "/tag/",
+    "/tags/",
+]
+
+
+class ExtractedPost(BaseModel):
+    """Extracted post information from chronological content page."""
+
+    url: str = Field(description="Full URL to the post/document")
+    title: str = Field(description="Title of the post")
+    date: str | None = Field(
+        default=None, description="Published date in ISO format (YYYY-MM-DD) if found"
+    )
+    excerpt: str | None = Field(default=None, description="Brief excerpt or description")
+
+
+class ChronologicalContentExtraction(BaseModel):
+    """Collection of extracted posts from a chronological content page."""
+
+    posts: list[ExtractedPost] = Field(description="List of posts extracted from the page")
+
+
+class ExtractChronologicalContentSignature(Signature):
+    """Extract chronological content (blog posts, release notes) from HTML/markdown."""
+
+    content: str = dspy.InputField(
+        desc="HTML or markdown content of a blogroll, release notes, or changelog page"
+    )
+    base_url: str = dspy.InputField(desc="Base URL of the page for resolving relative links")
+    extraction: ChronologicalContentExtraction = dspy.OutputField(
+        desc="Extracted posts with URLs, titles, dates, and excerpts"
+    )
+
+
+class BlogrollCandidate(BaseModel):
+    """A candidate URL identified as likely containing chronological content."""
+
+    url: str = Field(description="The full URL of the candidate page")
+    type: str = Field(
+        description="Type of page: 'blog_index', 'changelog', 'release_notes', 'archive', 'category', or 'tag'"
+    )
+    priority: int = Field(
+        description="Priority score 1-10, where 10 is highest priority (main indexes, changelogs)"
+    )
+    reasoning: str = Field(description="Brief explanation of why this URL is a good candidate")
+
+
+class BlogrollCandidateList(BaseModel):
+    """List of identified blogroll/changelog candidates."""
+
+    candidates: list[BlogrollCandidate] = Field(
+        description="Prioritized list of URLs that likely contain chronological content with dates"
+    )
+
+
+class IdentifyBlogrollCandidatesSignature(Signature):
+    """Identify URLs from a sitemap that are most likely to contain chronological content listings."""
+
+    urls_sample: str = dspy.InputField(desc="Pre-filtered URLs from the sitemap to analyze")
+    base_domain: str = dspy.InputField(desc="The base domain being analyzed (e.g., 'getdbt.com')")
+    candidates: BlogrollCandidateList = dspy.OutputField(
+        desc="List of ALL candidate URLs that match criteria for scraping chronological content"
+    )
+
+
+def identify_blogroll_candidates(
+    sitemap_urls: list[str],
+    llm_model: str = KurtConfig.DEFAULT_INDEXING_LLM_MODEL,
+    max_candidates: int = 20,
+) -> list[dict]:
+    """
+    Identify potential blogroll/changelog pages from sitemap URLs using hybrid approach.
+
+    Uses a two-stage approach:
+    1. Pre-filter with pattern matching to reduce URL set
+    2. LLM semantic analysis for final prioritization
+
+    This combines efficiency of regex filtering with semantic understanding of LLMs.
+
+    Args:
+        sitemap_urls: List of URLs discovered from sitemap
+        llm_model: LLM model to use for analysis (default: gpt-4o-mini)
+        max_candidates: Maximum number of candidates to return (default: 20)
+
+    Returns:
+        List of candidate pages sorted by priority:
+            - url: str (candidate URL)
+            - type: str (blog_index, changelog, release_notes, archive, category, tag)
+            - priority: int (1-10, higher = more important)
+            - reasoning: str (why this is a good candidate)
+
+    Example:
+        >>> urls = [
+        ...     "https://www.getdbt.com/blog",
+        ...     "https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes",
+        ... ]
+        >>> identify_blogroll_candidates(urls)
+        [
+            {
+                "url": "https://www.getdbt.com/blog",
+                "type": "blog_index",
+                "priority": 10,
+                "reasoning": "Main blog index page"
+            },
+            ...
+        ]
+    """
+    # Normalize all URLs
+    normalized_urls = list(set(normalize_url(url) for url in sitemap_urls))
+
+    # Get base domain
+    if not normalized_urls:
+        return []
+
+    parsed_first = urlparse(normalized_urls[0])
+    base_domain = parsed_first.netloc
+
+    # STAGE 1: Pre-filter with pattern matching
+    # Look for URLs containing key patterns for chronological content
+    patterns = [
+        "blog",
+        "news",
+        "changelog",
+        "release",
+        "updates",
+        "versions",
+        "whats-new",
+        "announcements",
+        "archive",
+        "category",
+        "upgrade",
+    ]
+
+    pre_filtered = []
+    for url in normalized_urls:
+        url_lower = url.lower()
+        parsed = urlparse(url)
+        path = parsed.path.lower()
+
+        # Check if URL contains any of our patterns
+        if any(pattern in url_lower for pattern in patterns):
+            # Calculate path depth
+            path_segments = [p for p in path.split("/") if p]
+            path_depth = len(path_segments)
+            last_segment = path_segments[-1] if path_segments else ""
+
+            # EXCLUSIONS: Skip these entirely
+            # 1. Author pages
+            if "/author/" in path or "/authors/" in path:
+                continue
+
+            # 2. Tag pages (too granular, too many)
+            if "/tags/" in path or "/tag/" in path or path.endswith("/tags"):
+                continue
+
+            # 3. Pagination pages (we auto-follow pagination anyway)
+            if re.match(r".*/page/\d+$", path):
+                continue
+
+            # 4. Individual blog posts (deep paths under /blog/)
+            if "/blog/" in path and path_depth >= 3:
+                # Allow special blog subdirectories (indexes)
+                special_blog_paths = ["archive", "category", "categories", "page"]
+                if not any(special in path for special in special_blog_paths):
+                    # This looks like an individual post: /blog/2024/10/my-post
+                    continue
+
+            # 5. Very long last segments (likely individual posts)
+            if len(last_segment) > 50:
+                continue
+
+            # 6. Common individual post patterns in URL
+            individual_post_keywords = [
+                "announcing-",
+                "introducing-",
+                "guide-to-",
+                "how-to-",
+                "what-is-",
+                "tutorial-",
+                "-guide-to-",
+                "-how-to-",
+                "understanding-",
+            ]
+            if any(keyword in last_segment for keyword in individual_post_keywords):
+                continue
+
+            # If we made it here, it's a good candidate
+            pre_filtered.append(url)
+
+    print(f"Pre-filtered: {len(pre_filtered)} candidates from {len(normalized_urls)} URLs")
+
+    # If pre-filtering produced too few results, widen the net
+    if len(pre_filtered) < max_candidates * 2:
+        # Add URLs with short paths (likely index pages)
+        for url in normalized_urls:
+            if url in pre_filtered:
+                continue
+
+            parsed = urlparse(url)
+            path_segments = [p for p in parsed.path.split("/") if p]
+            path_depth = len(path_segments)
+
+            # Short paths are often indexes
+            if path_depth <= 2:
+                pre_filtered.append(url)
+
+    # Deduplicate and limit
+    # Since we're sending paths (not full URLs), we can handle more candidates
+    pre_filtered = list(set(pre_filtered))[:500]  # Max 500 paths for LLM analysis
+
+    if not pre_filtered:
+        print("No candidates found after pre-filtering")
+        return []
+
+    # STAGE 2: LLM semantic analysis on filtered set
+    # Configure DSPy
+    lm = dspy.LM(llm_model)
+    dspy.configure(lm=lm)
+
+    # Prepare filtered URLs for LLM
+    urls_text = "\n".join(pre_filtered)
+
+    # Create detailed prompt - emphasize being INCLUSIVE
+    prompt = f"""Analyze these pre-filtered URLs from {base_domain} and identify ALL pages that are good candidates for scraping chronological content (blog posts with dates, changelogs, release notes).
+
+These URLs have been pre-filtered to exclude individual posts, tags, author pages, and pagination. Your job is to identify ALL valuable candidates, up to {max_candidates} maximum.
+
+IMPORTANT: Be INCLUSIVE. Return ALL URLs that match these criteria (don't filter aggressively):
+
+PRIORITIZE:
+1. Main blog/news indexes (e.g., /blog, /news) - Priority 10
+2. Changelog and release notes pages - Priority 10
+3. Version/upgrade documentation pages - Priority 9
+4. Blog archives and category pages - Priority 8
+
+Return ALL candidates that fit these criteria, up to {max_candidates} maximum. Do not be overly selective.
+
+For each candidate, provide:
+- The exact URL (from the list below)
+- Type: blog_index, changelog, release_notes, version, archive, or category
+- Priority: 1-10 (10 = highest)
+- Reasoning: Why this URL is valuable for date extraction
+
+Pre-filtered URLs ({len(pre_filtered)} total):
+{urls_text}"""
+
+    # Use LLM to identify candidates
+    identifier = ChainOfThought(IdentifyBlogrollCandidatesSignature)
+
+    try:
+        result = identifier(urls_sample=prompt, base_domain=base_domain)
+
+        # Convert to list format
+        candidates = []
+        seen_urls = set()  # Deduplicate
+        for candidate in result.candidates.candidates[:max_candidates]:
+            normalized = normalize_url(candidate.url)
+            if normalized not in seen_urls:
+                candidates.append(
+                    {
+                        "url": normalized,
+                        "type": candidate.type,
+                        "priority": candidate.priority,
+                        "reasoning": candidate.reasoning,
+                    }
+                )
+                seen_urls.add(normalized)
+
+        # Sort by priority (highest first)
+        candidates.sort(key=lambda x: -x["priority"])
+
+        return candidates
+
+    except Exception as e:
+        print(f"Error using LLM to identify candidates: {e}")
+        # Fallback: return empty list
+        return []
+
+
+def extract_chronological_content(
+    url: str,
+    llm_model: str = KurtConfig.DEFAULT_INDEXING_LLM_MODEL,
+    max_posts: int = 100,
+    follow_pagination: bool = True,
+    max_pages: int = 10,
+) -> list[dict]:
+    """
+    Extract blog posts, release notes, or changelog entries from a page using LLM.
+
+    This function handles both:
+    - Blogroll pages (explicit dates on each post)
+    - Release notes pages (date headers with links underneath)
+
+    The LLM analyzes the page structure and extracts:
+    - Post URLs (converts relative URLs to absolute)
+    - Titles
+    - Dates (explicit or inferred from headers)
+    - Excerpts (if available)
+    - Pagination links (to follow multi-page listings)
+
+    Args:
+        url: URL of blogroll, release notes, or changelog page
+        llm_model: LLM model to use for extraction (default: gpt-4o-mini)
+        max_posts: Maximum total posts to extract across all pages (default: 100)
+        follow_pagination: If True, follow "next page" links (default: True)
+        max_pages: Maximum number of pages to scrape (default: 10)
+
+    Returns:
+        List of dicts with keys:
+            - url: str (full URL to post)
+            - title: str (post title)
+            - date: datetime or None (published date if found)
+            - excerpt: str or None (post description)
+
+    Example:
+        >>> posts = extract_chronological_content(
+        ...     "https://www.getdbt.com/blog",
+        ...     follow_pagination=True,
+        ...     max_pages=5
+        ... )
+        >>> len(posts)
+        87  # Got posts from 5 pages
+    """
+    # Initialize
+    all_posts = []
+    seen_urls = set()
+    current_url = url
+    pages_scraped = 0
+
+    # Configure DSPy with specified model
+    lm = dspy.LM(llm_model)
+    dspy.configure(lm=lm)
+
+    # Get base URL for resolving relative links
+    parsed = urlparse(url)
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+    # Use LLM to extract structured data
+    extractor = ChainOfThought(ExtractChronologicalContentSignature)
+
+    # Loop through pages
+    while current_url and pages_scraped < max_pages and len(all_posts) < max_posts:
+        # Fetch page content
+        try:
+            response = httpx.get(current_url, timeout=30.0, follow_redirects=True)
+            response.raise_for_status()
+            html = response.text
+        except Exception as e:
+            print(f"Error fetching {current_url}: {e}")
+            break
+
+        # Extract markdown using trafilatura (cleaner for LLM)
+        markdown = trafilatura.extract(
+            html, output_format="markdown", include_links=True, url=current_url
+        )
+
+        if not markdown:
+            print(f"No content extracted from {current_url}")
+            break
+
+        try:
+            # Add instruction to the content
+            remaining_posts = max_posts - len(all_posts)
+            content_with_instructions = f"""Extract all blog posts, release notes, or changelog entries from this page.
+
+IMPORTANT INSTRUCTIONS:
+1. For blogroll pages: Extract the URL, title, and date for each post
+2. For release notes pages with date headers: Assign the header date to all links under that header
+3. Convert all relative URLs to absolute URLs using base_url: {base_url}
+4. Parse dates into ISO format (YYYY-MM-DD)
+5. Limit to first {remaining_posts} posts
+6. If a date is ambiguous or missing, set it to null
+
+CONTENT:
+{markdown[:15000]}"""  # Limit content length to avoid token limits
+
+            result = extractor(content=content_with_instructions, base_url=base_url)
+
+            # Parse and validate results
+            for post in result.extraction.posts:
+                if len(all_posts) >= max_posts:
+                    break
+
+                # Parse date if present
+                date_obj = None
+                if post.date:
+                    try:
+                        date_obj = datetime.fromisoformat(post.date)
+                    except (ValueError, AttributeError):
+                        # Try other common formats
+                        for fmt in ["%Y-%m-%d", "%B %d, %Y", "%b %d, %Y"]:
+                            try:
+                                date_obj = datetime.strptime(post.date, fmt)
+                                break
+                            except ValueError:
+                                continue
+
+                # Resolve relative URLs
+                post_url = post.url
+                if not post_url.startswith(("http://", "https://")):
+                    # Resolve relative URL
+                    if post_url.startswith("/"):
+                        post_url = base_url + post_url
+                    else:
+                        post_url = base_url + "/" + post_url
+
+                # Normalize URL to avoid duplicates
+                post_url = normalize_url(post_url)
+
+                # Skip if already seen
+                if post_url in seen_urls:
+                    continue
+
+                seen_urls.add(post_url)
+                all_posts.append(
+                    {
+                        "url": post_url,
+                        "title": post.title,
+                        "date": date_obj,
+                        "excerpt": post.excerpt,
+                    }
+                )
+
+            pages_scraped += 1
+
+            # Find next page link if pagination is enabled
+            if follow_pagination and pages_scraped < max_pages and len(all_posts) < max_posts:
+                next_url = _find_next_page_link(html, current_url, base_url)
+                if next_url and next_url != current_url:
+                    current_url = next_url
+                    print(f"  Following pagination to page {pages_scraped + 1}...")
+                else:
+                    break
+            else:
+                break
+
+        except Exception as e:
+            print(f"Error extracting content from {current_url}: {e}")
+            break
+
+    return all_posts
+
+
+def _find_next_page_link(html: str, current_url: str, base_url: str) -> str | None:
+    """
+    Find the "next page" link in HTML pagination controls using regex.
+
+    Args:
+        html: HTML content of current page
+        current_url: Current page URL
+        base_url: Base URL for resolving relative links
+
+    Returns:
+        URL of next page or None if not found
+    """
+    next_link = None
+
+    # Strategy 1: Look for <a rel="next" href="...">
+    match = re.search(
+        r'<a[^>]*\srel=["\']next["\'][^>]*\shref=["\']([^"\']+)["\']', html, re.IGNORECASE
+    )
+    if not match:
+        match = re.search(
+            r'<a[^>]*\shref=["\']([^"\']+)["\'][^>]*\srel=["\']next["\']', html, re.IGNORECASE
+        )
+
+    if match:
+        next_link = match.group(1)
+
+    # Strategy 2: Look for links with "Next", "Older", pagination symbols
+    if not next_link:
+        # Match <a href="..." ...>Next</a> or similar
+        pattern = r'<a[^>]*\shref=["\']([^"\']+)["\'][^>]*>(.*?)</a>'
+        matches = re.finditer(pattern, html, re.IGNORECASE | re.DOTALL)
+        for match in matches:
+            link_text = match.group(2)
+            if re.search(r"(next|older|→|›|»)", link_text, re.IGNORECASE):
+                next_link = match.group(1)
+                break
+
+    # Strategy 3: Look for pagination class patterns
+    if not next_link:
+        match = re.search(
+            r'<a[^>]*\sclass=["\'][^"\']*(?:next|pagination-next)[^"\']*["\'][^>]*\shref=["\']([^"\']+)["\']',
+            html,
+            re.IGNORECASE,
+        )
+        if match:
+            next_link = match.group(1)
+
+    # Resolve relative URL
+    if next_link:
+        # Decode HTML entities
+        next_link = next_link.replace("&amp;", "&")
+
+        if not next_link.startswith(("http://", "https://")):
+            if next_link.startswith("/"):
+                next_link = base_url + next_link
+            else:
+                # Relative to current URL
+                next_link = urljoin(current_url, next_link)
+
+        # Normalize and return
+        return normalize_url(next_link)
+
+    return None
+
+
+def map_blogrolls(
+    sitemap_urls: list[str],
+    llm_model: str = KurtConfig.DEFAULT_INDEXING_LLM_MODEL,
+    max_blogrolls: int = 10,
+    max_posts_per_blogroll: int = 100,
+) -> list[dict]:
+    """
+    Discover and map documents from blogroll/changelog pages.
+
+    This is the high-level function that:
+    1. Identifies potential blogroll pages from sitemap URLs
+    2. Extracts posts from those pages using LLM
+    3. Creates document records for discovered posts
+
+    Args:
+        sitemap_urls: List of URLs from sitemap (output of map_sitemap)
+        llm_model: LLM model to use for extraction
+        max_blogrolls: Maximum number of blogroll pages to scrape
+        max_posts_per_blogroll: Maximum posts to extract per page
+
+    Returns:
+        List of created documents with keys:
+            - document_id: UUID
+            - url: str
+            - title: str
+            - published_date: datetime or None
+            - status: str ('NOT_FETCHED')
+            - is_chronological: bool (True)
+            - discovery_method: str ('blogroll')
+            - discovery_url: str (the blogroll page URL)
+            - created: bool (whether document was newly created)
+
+    Example:
+        >>> # First map sitemap
+        >>> sitemap_docs = map_sitemap("https://www.getdbt.com/sitemap.xml")
+        >>> sitemap_urls = [doc["url"] for doc in sitemap_docs]
+        >>>
+        >>> # Then discover additional posts from blogrolls
+        >>> blogroll_docs = map_blogrolls(sitemap_urls, max_blogrolls=5)
+        >>> len(blogroll_docs)
+        42  # Found 42 additional blog posts not in sitemap
+    """
+    from sqlmodel import select
+
+    # Identify candidate blogroll pages
+    candidates = identify_blogroll_candidates(sitemap_urls)
+    print(f"Found {len(candidates)} potential blogroll/changelog pages")
+
+    # Limit to top candidates
+    candidates = candidates[:max_blogrolls]
+
+    session = get_session()
+    all_documents = []
+
+    for candidate in candidates:
+        blogroll_url = candidate["url"]
+        print(f"\nScraping {blogroll_url}...")
+
+        # Extract posts from this page
+        posts = extract_chronological_content(
+            blogroll_url, llm_model=llm_model, max_posts=max_posts_per_blogroll
+        )
+
+        print(f"  Found {len(posts)} posts")
+
+        # Create document records for each post
+        for post in posts:
+            # Check if document already exists
+            stmt = select(Document).where(Document.source_url == post["url"])
+            existing_doc = session.exec(stmt).first()
+
+            if existing_doc:
+                # Update discovery metadata if not set
+                updated = False
+                if not existing_doc.is_chronological:
+                    existing_doc.is_chronological = True
+                    updated = True
+                if not existing_doc.discovery_method:
+                    existing_doc.discovery_method = "blogroll"
+                    existing_doc.discovery_url = blogroll_url
+                    updated = True
+                if post["date"] and not existing_doc.published_date:
+                    existing_doc.published_date = post["date"]
+                    updated = True
+
+                if updated:
+                    session.commit()
+                    session.refresh(existing_doc)
+
+                all_documents.append(
+                    {
+                        "document_id": existing_doc.id,
+                        "url": existing_doc.source_url,
+                        "title": existing_doc.title,
+                        "published_date": existing_doc.published_date,
+                        "status": existing_doc.ingestion_status.value,
+                        "is_chronological": existing_doc.is_chronological,
+                        "discovery_method": existing_doc.discovery_method,
+                        "discovery_url": existing_doc.discovery_url,
+                        "created": False,
+                    }
+                )
+                continue
+
+            # Create new document
+            doc = Document(
+                title=post["title"],
+                source_type=SourceType.URL,
+                source_url=post["url"],
+                ingestion_status=IngestionStatus.NOT_FETCHED,
+                published_date=post["date"],
+                description=post["excerpt"],
+                is_chronological=True,
+                discovery_method="blogroll",
+                discovery_url=blogroll_url,
+            )
+
+            session.add(doc)
+            session.commit()
+            session.refresh(doc)
+
+            all_documents.append(
+                {
+                    "document_id": doc.id,
+                    "url": doc.source_url,
+                    "title": doc.title,
+                    "published_date": doc.published_date,
+                    "status": doc.ingestion_status.value,
+                    "is_chronological": doc.is_chronological,
+                    "discovery_method": doc.discovery_method,
+                    "discovery_url": doc.discovery_url,
+                    "created": True,
+                }
+            )
+
+    print(f"\n✓ Total documents discovered from blogrolls: {len(all_documents)}")
+    print(f"  New: {sum(1 for d in all_documents if d['created'])}")
+    print(f"  Existing: {sum(1 for d in all_documents if not d['created'])}")
+
+    return all_documents
+
+
+def map_url_content(
+    url: str,
+    sitemap_path: str = None,
+    include_blogrolls: bool = False,
+    max_depth: int = None,
+    max_pages: int = 1000,
+    include_patterns: tuple = (),
+    exclude_patterns: tuple = (),
+    allow_external: bool = False,
+    dry_run: bool = False,
+    cluster_urls: bool = False,
+) -> dict:
+    """
+    High-level URL mapping function - discover content from web sources.
+
+    Handles:
+    - Sitemap detection and parsing
+    - Blogroll date extraction (optional)
+    - Crawling fallback if no sitemap
+    - Pattern filtering
+    - Document creation (NOT_FETCHED status)
+    - Optional clustering (if cluster_urls=True)
+
+    Args:
+        url: Base URL to map
+        sitemap_path: Override sitemap location
+        include_blogrolls: Enable LLM blogroll date extraction
+        max_depth: Crawl depth if no sitemap found
+        max_pages: Max pages to discover (default: 1000)
+        include_patterns: Include URL patterns (glob)
+        exclude_patterns: Exclude URL patterns (glob)
+        allow_external: Follow external links
+        dry_run: If True, discover URLs but don't save to database
+        cluster_urls: If True, automatically cluster documents after mapping
+
+    Returns:
+        dict with:
+            - discovered: List of discovered document dicts or URLs (if dry_run)
+            - total: Total count
+            - new: Count of new documents created (0 if dry_run)
+            - existing: Count of existing documents (0 if dry_run)
+            - method: Discovery method used (sitemap|blogrolls|crawl)
+            - dry_run: Boolean indicating if this was a dry run
+    """
+    from kurt.utils.url_utils import is_single_page_url
+
+    # DRY RUN MODE: Discover URLs without saving to database
+    if dry_run:
+        from kurt.content.map import _discover_sitemap_urls
+
+        discovery_method = "sitemap"
+
+        # Discover URLs from sitemap or crawling
+        try:
+            # Note: sitemap_path parameter is not used by _discover_sitemap_urls yet
+            discovered_urls = _discover_sitemap_urls(url)
+        except Exception as e:
+            # Sitemap failed - try crawling if max_depth is specified
+            if max_depth is not None:
+                logger.info(
+                    f"Sitemap discovery failed in dry-run: {e}. Trying crawl with max_depth={max_depth}"
+                )
+                discovered_urls = crawl_website(
+                    homepage=url,
+                    max_depth=max_depth,
+                    max_pages=max_pages,
+                    allow_external=allow_external,
+                    include_patterns=include_patterns,
+                    exclude_patterns=exclude_patterns,
+                )
+                discovery_method = "crawl"
+            else:
+                # Fallback to single URL if discovery fails and no max_depth
+                discovered_urls = [url]
+
+        # Apply filters (if not already applied by crawl_website)
+        if discovery_method == "sitemap":
+            filtered_urls = []
+            for discovered_url in discovered_urls:
+                # Apply include patterns
+                if include_patterns:
+                    if not any(fnmatch(discovered_url, pattern) for pattern in include_patterns):
+                        continue
+
+                # Apply exclude patterns
+                if exclude_patterns:
+                    if any(fnmatch(discovered_url, pattern) for pattern in exclude_patterns):
+                        continue
+
+                filtered_urls.append(discovered_url)
+
+            # Apply limit
+            if max_pages:
+                filtered_urls = filtered_urls[:max_pages]
+        else:
+            # Crawling already applied filters
+            filtered_urls = discovered_urls
+
+        return {
+            "discovered": filtered_urls,  # Just URLs, not document objects
+            "total": len(filtered_urls),
+            "new": 0,  # Not saved
+            "existing": 0,  # Not checked
+            "method": discovery_method,
+            "dry_run": True,
+        }
+
+    # NORMAL MODE: Single page detection
+    if is_single_page_url(url):
+        # Single page - just create document
+        from kurt.content.fetch import add_document
+
+        doc_id = add_document(url)
+        result = {
+            "discovered": [{"url": url, "doc_id": str(doc_id), "created": True}],
+            "total": 1,
+            "new": 1,
+            "existing": 0,
+            "method": "single_page",
+            "dry_run": False,
+        }
+
+        # Auto-cluster if requested (though clustering 1 page doesn't make sense)
+        if cluster_urls:
+            from kurt.content.cluster import compute_topic_clusters
+
+            cluster_result = compute_topic_clusters()
+            result["clusters"] = cluster_result["clusters"]
+            result["cluster_count"] = len(cluster_result["clusters"])
+
+        return result
+
+    # NORMAL MODE: Multi-page discovery with filters
+    # Try sitemap first, fall back to crawling if requested and sitemap fails
+    docs = []
+    discovery_method = "sitemap"
+
+    try:
+        docs = map_sitemap(
+            url,
+            fetch_all=False,
+            discover_blogrolls=include_blogrolls,
+            max_blogrolls=50 if include_blogrolls else 10,
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+            limit=max_pages,
+        )
+    except (ValueError, Exception) as e:
+        # Sitemap failed - fall back to crawling if max_depth is specified
+        if max_depth is not None:
+            logger.info(
+                f"Sitemap discovery failed: {e}. Falling back to crawling with max_depth={max_depth}"
+            )
+
+            # Use crawler to discover URLs
+            crawled_urls = crawl_website(
+                homepage=url,
+                max_depth=max_depth,
+                max_pages=max_pages,
+                allow_external=allow_external,
+                include_patterns=include_patterns,
+                exclude_patterns=exclude_patterns,
+            )
+
+            # Create documents for crawled URLs
+            from kurt.content.fetch import add_document
+
+            for crawled_url in crawled_urls:
+                try:
+                    doc_id = add_document(crawled_url)
+                    docs.append(
+                        {
+                            "url": crawled_url,
+                            "doc_id": str(doc_id),
+                            "created": True,
+                        }
+                    )
+                except Exception as doc_err:
+                    logger.warning(f"Failed to create document for {crawled_url}: {doc_err}")
+
+            discovery_method = "crawl"
+        else:
+            # No max_depth specified and sitemap failed - re-raise the error
+            raise
+
+    new_count = sum(1 for d in docs if d.get("created", False))
+    existing_count = len(docs) - new_count
+
+    result = {
+        "discovered": docs,
+        "total": len(docs),
+        "new": new_count,
+        "existing": existing_count,
+        "method": discovery_method,
+        "dry_run": False,
+    }
+
+    # Auto-cluster if requested
+    if cluster_urls and len(docs) > 0:
+        from kurt.content.cluster import compute_topic_clusters
+
+        cluster_result = compute_topic_clusters()
+        result["clusters"] = cluster_result["clusters"]
+        result["cluster_count"] = len(cluster_result["clusters"])
+
+    return result
+
+
+def _add_single_file_to_db(file_path: Path) -> dict:
+    """
+    Internal function: Add a single markdown file to the database.
+
+    Args:
+        file_path: Path to .md file
+
+    Returns:
+        Dict with keys: doc_id, created, skipped, reason (if skipped)
+    """
+    import shutil
+    from uuid import uuid4
+
+    from sqlmodel import select
+
+    from kurt.config import load_config
+    from kurt.utils.file_utils import compute_file_hash
+    from kurt.utils.source_detection import validate_file_extension
+
+    # Validate file
+    is_valid, error_msg = validate_file_extension(file_path)
+    if not is_valid:
+        raise ValueError(error_msg)
+
+    # Compute content hash
+    content_hash = compute_file_hash(file_path)
+
+    # Check if document already exists (by content hash)
+    session = get_session()
+    stmt = select(Document).where(Document.content_hash == content_hash)
+    existing_doc = session.exec(stmt).first()
+
+    if existing_doc:
+        return {
+            "doc_id": str(existing_doc.id),
+            "created": False,
+            "skipped": True,
+            "reason": "Content already exists",
+        }
+
+    # Copy file to sources directory
+    config = load_config()
+    sources_dir = config.get_absolute_sources_path()
+    target_path = sources_dir / file_path.name
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(file_path, target_path)
+    relative_content_path = str(target_path.relative_to(sources_dir))
+
+    # Read file content for title extraction
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Extract title from first heading or filename
+    title = None
+    for line in content.split("\n"):
+        if line.startswith("# "):
+            title = line[2:].strip()
+            break
+    if not title:
+        title = file_path.stem.replace("-", " ").replace("_", " ").title()
+
+    # Create document record
+    doc = Document(
+        id=uuid4(),
+        title=title,
+        source_type=SourceType.FILE_UPLOAD,
+        source_url=f"file://{file_path.absolute()}",
+        content_path=relative_content_path,
+        ingestion_status=IngestionStatus.FETCHED,
+        content_hash=content_hash,
+    )
+
+    session.add(doc)
+    session.commit()
+    session.refresh(doc)
+
+    return {
+        "doc_id": str(doc.id),
+        "created": True,
+        "skipped": False,
+    }
+
+
+def map_folder_content(
+    folder_path: str,
+    include_patterns: tuple = (),
+    exclude_patterns: tuple = (),
+    dry_run: bool = False,
+    cluster_urls: bool = False,
+) -> dict:
+    """
+    High-level folder mapping function - discover content from local files.
+
+    Args:
+        folder_path: Path to folder to scan
+        include_patterns: Include file patterns (glob)
+        exclude_patterns: Exclude file patterns (glob)
+        dry_run: If True, discover files but don't save to database
+        cluster_urls: If True, automatically cluster documents after mapping
+
+    Returns:
+        dict with:
+            - discovered: List of file paths (strings if dry_run, dicts otherwise)
+            - total: Total count
+            - new: Count of new files (0 if dry_run)
+            - existing: Count of existing files (0 if dry_run)
+            - dry_run: Boolean indicating if this was a dry run
+            - clusters: List of clusters (if cluster_urls=True)
+            - cluster_count: Number of clusters (if cluster_urls=True)
+    """
+    from fnmatch import fnmatch
+
+    from kurt.utils.source_detection import discover_markdown_files
+
+    folder = Path(folder_path)
+    md_files = discover_markdown_files(folder, recursive=True)
+
+    # Apply filters
+    if include_patterns:
+        filtered = []
+        for file_path in md_files:
+            rel_path = str(file_path.relative_to(folder))
+            if any(fnmatch(rel_path, pattern) for pattern in include_patterns):
+                filtered.append(file_path)
+        md_files = filtered
+
+    if exclude_patterns:
+        filtered = []
+        for file_path in md_files:
+            rel_path = str(file_path.relative_to(folder))
+            if not any(fnmatch(rel_path, pattern) for pattern in exclude_patterns):
+                filtered.append(file_path)
+        md_files = filtered
+
+    # Handle dry-run mode
+    if dry_run:
+        # Return file paths as strings without saving to database
+        return {
+            "discovered": [str(file_path) for file_path in md_files],
+            "total": len(md_files),
+            "new": 0,
+            "existing": 0,
+            "dry_run": True,
+        }
+
+    # Add files to database (normal mode)
+    results = []
+    for file_path in md_files:
+        try:
+            result = _add_single_file_to_db(file_path)
+            results.append(
+                {
+                    "path": str(file_path),
+                    "doc_id": result["doc_id"],
+                    "created": result["created"],
+                }
+            )
+        except Exception as e:
+            results.append(
+                {
+                    "path": str(file_path),
+                    "error": str(e),
+                    "created": False,
+                }
+            )
+
+    new_count = sum(1 for r in results if r.get("created", False))
+    existing_count = len(results) - new_count
+
+    result_dict = {
+        "discovered": results,
+        "total": len(results),
+        "new": new_count,
+        "existing": existing_count,
+        "dry_run": False,
+    }
+
+    # Auto-cluster if requested
+    if cluster_urls and len(results) > 0:
+        from kurt.content.cluster import compute_topic_clusters
+
+        cluster_result = compute_topic_clusters()
+        result_dict["clusters"] = cluster_result["clusters"]
+        result_dict["cluster_count"] = len(cluster_result["clusters"])
+
+    return result_dict
+
+
+def map_cms_content(
+    platform: str,
+    instance: str,
+    content_type: str = None,
+    status: str = None,
+    limit: int = None,
+    cluster_urls: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """
+    High-level CMS mapping function - discover content from CMS platforms.
+
+    Handles:
+    - CMS adapter initialization
+    - Bulk document discovery via CMS API
+    - Document creation with platform/instance/id format
+    - Optional clustering
+
+    Args:
+        platform: CMS platform name (sanity, contentful, wordpress)
+        instance: Instance name (prod, staging, etc)
+        content_type: Filter by content type (optional)
+        status: Filter by status (draft, published) (optional)
+        limit: Maximum number of documents to discover (optional)
+        cluster_urls: If True, automatically cluster documents after mapping
+        dry_run: If True, discover documents but don't save to database
+
+    Returns:
+        dict with:
+            - discovered: List of discovered document dicts or metadata (if dry_run)
+            - total: Total count
+            - new: Count of new documents created (0 if dry_run)
+            - existing: Count of existing documents (0 if dry_run)
+            - method: Discovery method (always "cms_api")
+            - dry_run: Boolean indicating if this was a dry run
+    """
+    from kurt.cms import get_adapter
+    from kurt.cms.config import get_platform_config
+
+    # Get CMS adapter
+    cms_config = get_platform_config(platform, instance)
+    adapter = get_adapter(platform, cms_config)
+
+    # Discover documents via CMS API
+    try:
+        cms_documents = adapter.list_all(
+            content_type=content_type,
+            status=status,
+            limit=limit,
+        )
+    except Exception as e:
+        logger.error(f"CMS discovery failed: {e}")
+        raise ValueError(f"Failed to discover documents from {platform}/{instance}: {e}")
+
+    # DRY RUN MODE: Return metadata without saving
+    if dry_run:
+        return {
+            "discovered": cms_documents,  # List of metadata dicts
+            "total": len(cms_documents),
+            "new": 0,  # Not saved
+            "existing": 0,  # Not checked
+            "method": "cms_api",
+            "dry_run": True,
+        }
+
+    # NORMAL MODE: Create documents in database
+    # Get content_type_mappings for auto-assigning content types
+    content_type_mappings = cms_config.get("content_type_mappings", {})
+
+    results = []
+    session = get_session()
+
+    for doc_meta in cms_documents:
+        # Get schema/content_type name and slug
+        schema = doc_meta.get("content_type")  # e.g., "article", "universeItem"
+        slug = doc_meta.get("slug", "untitled")
+        cms_doc_id = doc_meta["id"]
+
+        # Construct semantic source_url in format: platform/instance/schema/slug
+        source_url = f"{platform}/{instance}/{schema}/{slug}"
+
+        # Get inferred content type from schema mapping
+        inferred_content_type = None
+        if schema in content_type_mappings:
+            inferred_content_type_str = content_type_mappings[schema].get("inferred_content_type")
+            if inferred_content_type_str:
+                try:
+                    # Import ContentType enum
+                    from kurt.db.models import ContentType
+                    # Convert string to enum (e.g., "article" -> ContentType.ARTICLE)
+                    inferred_content_type = ContentType[inferred_content_type_str.upper()]
+                except (KeyError, AttributeError):
+                    logger.warning(f"Invalid content_type '{inferred_content_type_str}' for schema '{schema}'")
+
+        # Check if document already exists (by source_url)
+        existing_doc = (
+            session.query(Document)
+            .filter(Document.source_url == source_url)
+            .first()
+        )
+
+        if existing_doc:
+            # Document already mapped
+            results.append({
+                "url": source_url,
+                "doc_id": str(existing_doc.id),
+                "title": doc_meta.get("title"),
+                "content_type": schema,
+                "created": False,
+            })
+            continue
+
+        # Create new document with all metadata
+        new_doc = Document(
+            source_url=source_url,
+            cms_document_id=cms_doc_id,  # Store CMS ID for fetching
+            source_type=SourceType.WEB,  # Use WEB type for now (CMS content is web-accessible)
+            ingestion_status=IngestionStatus.NOT_FETCHED,
+            title=doc_meta.get("title", "Untitled"),
+            description=doc_meta.get("description"),  # For clustering
+            content_type=inferred_content_type,  # Auto-assigned from schema
+        )
+
+        session.add(new_doc)
+        session.commit()
+
+        results.append({
+            "url": source_url,
+            "doc_id": str(new_doc.id),
+            "title": doc_meta.get("title"),
+            "content_type": schema,
+            "created": True,
+        })
+
+        logger.info(f"Created NOT_FETCHED document: {source_url} (CMS ID: {cms_doc_id})")
+
+    session.close()
+
+    # Calculate counts
+    new_count = sum(1 for r in results if r.get("created", False))
+    existing_count = len(results) - new_count
+
+    result_dict = {
+        "discovered": results,
+        "total": len(results),
+        "new": new_count,
+        "existing": existing_count,
+        "method": "cms_api",
+        "dry_run": False,
+    }
+
+    # Auto-cluster if requested
+    if cluster_urls and len(results) > 0:
+        from kurt.content.cluster import compute_topic_clusters
+
+        cluster_result = compute_topic_clusters()
+        result_dict["clusters"] = cluster_result["clusters"]
+        result_dict["cluster_count"] = len(cluster_result["clusters"])
+
+    return result_dict


### PR DESCRIPTION
## Summary

Centralized all configuration defaults and validation logic in the `KurtConfig` BaseModel, eliminating scattered hardcoded values and providing a single source of truth for configuration.

## Key Changes

### 1. Configuration Constants (src/kurt/config/base.py)
Added `ClassVar` constants for all defaults:
- `DEFAULT_DB_PATH`, `DEFAULT_SOURCES_PATH`, `DEFAULT_PROJECTS_PATH`, `DEFAULT_RULES_PATH`
- `DEFAULT_INDEXING_LLM_MODEL` = "openai/gpt-4o-mini"
- `DEFAULT_FETCH_ENGINE` = "trafilatura"
- `VALID_FETCH_ENGINES` = ["trafilatura", "firecrawl"]
- `KNOWN_LLM_PROVIDERS` = ["openai", "anthropic", "google", ...]

### 2. Smart LLM Validation
Created `validate_llm_model_format()` method that:
- Validates format: `provider/model-name`
- Warns (doesn't block) for unknown providers since DSPy is extensible
- Returns clear error messages

### 3. Code Updates
- **fetch.py**: Uses `VALID_FETCH_ENGINES` and `DEFAULT_FETCH_ENGINE`
- **map.py**: Replaced 4 hardcoded `"openai/gpt-4o-mini"` references
- **cli.py**: Init command uses constants with dynamic help text
- **create_config()**: Directly references KurtConfig defaults (no more `None` checks)

### 4. Test Improvements
- Fixed test fixtures to use `create_config()` instead of manual file creation
- Proper cleanup of working directories in fixtures

## Benefits

✅ **Single Source of Truth** - All defaults in one place  
✅ **Type Safety** - ClassVar prevents accidental field creation  
✅ **Easy Maintenance** - Change once, updates everywhere  
✅ **Better Testing** - Fixtures properly leverage config module  
✅ **Extensibility** - Validates but doesn't block unknown LLM providers  
✅ **Clean Code** - Direct reference to constants, no verbose `None` checks

## Test Results

```bash
✅ 378 tests passing
✅ All config tests pass
✅ All integration tests pass
```

## Example Usage

```python
from kurt.config import KurtConfig

# Access defaults anywhere
db_path = KurtConfig.DEFAULT_DB_PATH

# Validate engine
if engine not in KurtConfig.VALID_FETCH_ENGINES:
    raise ValueError(f"Invalid engine: {engine}")

# Validate LLM model
is_valid, msg = KurtConfig.validate_llm_model_format("openai/gpt-4o")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)