### PR TITLE
Fix --include filter in list-entities command

### DIFF
--- a/src/kurt/db/knowledge_graph.py
+++ b/src/kurt/db/knowledge_graph.py
@@ -326,7 +326,7 @@ def list_entities_by_type(
             doc_stmt = select(Document).where(Document.ingestion_status == IngestionStatus.FETCHED)
             matching_docs = s.exec(doc_stmt).all()
             matching_doc_ids = {
-                str(d.id)
+                d.id
                 for d in matching_docs
                 if (d.source_url and fnmatch(d.source_url, include_pattern))
                 or (d.content_path and fnmatch(d.content_path, include_pattern))


### PR DESCRIPTION
Fixed bug where --include pattern filter wasn't working for kurt content list-entities command.

The issue was a type mismatch: document IDs were being stored as UUID objects in entity_docs but converted to strings when filtering, causing the set intersection to always be empty.

Changed line 329 from `str(d.id)` to `d.id` to keep UUIDs as UUID objects for proper set intersection.

Now --include filtering works correctly:
- kurt content list-entities topic --include "*/article/*"
- kurt content list-entities all --include "*/article/how-do-you-train*"

🤖 Generated with [Claude Code](https://claude.com/claude-code)