### PR TITLE
feat: Add WorkflowStepError structured error handling for indexing pipeline

### DIFF
--- a/src/kurt/core/__init__.py
+++ b/src/kurt/core/__init__.py
@@ -18,6 +18,12 @@ from .dspy_helpers import (
     LLMRateLimitError,
     get_dspy_lm,
 )
+from .errors import (
+    WorkflowDocumentRef,
+    WorkflowStepError,
+    make_doc_ref,
+    record_step_error,
+)
 from .mixins import (
     LLMTelemetryMixin,
     PipelineModelBase,
@@ -77,4 +83,9 @@ __all__ = [
     "LLMAuthenticationError",
     "LLMRateLimitError",
     "LLMAPIError",
+    # Workflow Step Errors
+    "WorkflowStepError",
+    "WorkflowDocumentRef",
+    "record_step_error",
+    "make_doc_ref",
 ]

--- a/src/kurt/core/errors.py
+++ b/src/kurt/core/errors.py
@@ -1,0 +1,349 @@
+"""Structured error handling for workflow steps.
+
+This module provides error classes for representing step/model failures with
+enough metadata for dashboards and CLI surfaces.
+
+Usage:
+    from kurt.core import WorkflowStepError, WorkflowDocumentRef
+
+    # For per-document errors (skip and continue)
+    raise WorkflowStepError(
+        step="indexing.section_extractions",
+        message="LLM rate limit exceeded",
+        action="skip_record",
+        severity="recoverable",
+        documents=[
+            WorkflowDocumentRef(document_id="doc1", section_id="sec1"),
+        ],
+        metadata={"llm_model": "claude-3-haiku"},
+        cause=original_exception,
+    )
+
+    # For systemic errors (fail the model)
+    raise WorkflowStepError(
+        step="indexing.entity_resolution",
+        message="Database constraint violation",
+        action="fail_model",
+        severity="fatal",
+        documents=[WorkflowDocumentRef(document_id="doc1")],
+        cause=db_exception,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
+
+if TYPE_CHECKING:
+    from .model_runner import PipelineContext
+
+logger = logging.getLogger(__name__)
+
+
+# Type aliases for clarity
+StepName = str  # e.g., "indexing.section_extractions"
+ActionType = Literal["fail_model", "skip_record", "retry"]
+SeverityType = Literal["fatal", "recoverable", "info"]
+
+
+@dataclass(slots=True)
+class WorkflowDocumentRef:
+    """Reference to a document involved in a workflow error.
+
+    This mirrors per-row identifiers used in indexing tables like SectionExtractionRow.
+    All fields are optional to support different granularity levels.
+
+    Attributes:
+        document_id: Primary document identifier
+        section_id: Section within document (for section-level errors)
+        source_url: Original source URL of the document
+        cms_document_id: External CMS identifier
+        hash: Content hash for change detection
+        entity_name: Entity name (for entity resolution errors)
+        claim_hash: Claim hash (for claim resolution errors)
+    """
+
+    document_id: Optional[str] = None
+    section_id: Optional[str] = None
+    source_url: Optional[str] = None
+    cms_document_id: Optional[str] = None
+    hash: Optional[str] = None
+    entity_name: Optional[str] = None
+    claim_hash: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary, excluding None values."""
+        from dataclasses import fields
+
+        return {
+            f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None
+        }
+
+    def __str__(self) -> str:
+        """Human-readable representation."""
+        parts = []
+        if self.document_id:
+            parts.append(f"doc={self.document_id}")
+        if self.section_id:
+            parts.append(f"sec={self.section_id}")
+        if self.entity_name:
+            parts.append(f"entity={self.entity_name}")
+        if self.claim_hash:
+            parts.append(f"claim={self.claim_hash[:8]}")
+        return f"DocRef({', '.join(parts)})" if parts else "DocRef()"
+
+
+class WorkflowStepError(Exception):
+    """Structured exception for workflow step failures.
+
+    This exception carries rich context about failures, enabling:
+    - Dashboard/CLI surfaces to display meaningful error information
+    - Pipeline runners to make informed decisions about continuation
+    - Event emitters to record detailed error telemetry
+
+    Attributes:
+        step: The workflow step that failed (e.g., "indexing.section_extractions")
+        message: Human-readable error description
+        action: How the pipeline should respond:
+            - "fail_model": Stop the model and propagate the error
+            - "skip_record": Skip the affected documents and continue
+            - "retry": Indicate the operation can be retried
+        severity: Error severity level:
+            - "fatal": Systemic failure, model cannot continue
+            - "recoverable": Per-document failure, pipeline can continue
+            - "info": Informational, logged but not necessarily problematic
+        documents: Tuple of document references affected by this error
+        metadata: Additional key-value context (e.g., llm_model, batch_size)
+        cause: The underlying exception that caused this error
+        retryable: Whether the operation can be retried
+
+    Example:
+        # LLM rate limit on specific sections
+        error = WorkflowStepError(
+            step="indexing.section_extractions",
+            message="OpenAI rate limit exceeded",
+            action="skip_record",
+            severity="recoverable",
+            documents=[
+                WorkflowDocumentRef(document_id="doc1", section_id="sec1"),
+                WorkflowDocumentRef(document_id="doc1", section_id="sec2"),
+            ],
+            metadata={"llm_model": "gpt-4", "retry_after": 60},
+            retryable=True,
+        )
+
+        # Database constraint violation
+        error = WorkflowStepError(
+            step="indexing.entity_resolution",
+            message="Duplicate entity name in batch",
+            action="fail_model",
+            severity="fatal",
+            documents=[WorkflowDocumentRef(entity_name="Python")],
+            cause=integrity_error,
+        )
+    """
+
+    def __init__(
+        self,
+        step: StepName,
+        message: str,
+        action: ActionType = "fail_model",
+        severity: SeverityType = "fatal",
+        documents: Optional[Tuple[WorkflowDocumentRef, ...]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        cause: Optional[Exception] = None,
+        retryable: bool = False,
+    ):
+        self.step = step
+        self.message = message
+        self.action = action
+        self.severity = severity
+        self.documents = documents or ()
+        self.metadata = metadata or {}
+        self.cause = cause
+        self.retryable = retryable
+
+        # Build exception message
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
+        """Build the exception message string."""
+        parts = [f"[{self.step}] {self.message}"]
+        if self.documents:
+            doc_count = len(self.documents)
+            parts.append(f"({doc_count} document{'s' if doc_count > 1 else ''} affected)")
+        if self.cause:
+            parts.append(f"Caused by: {type(self.cause).__name__}: {self.cause}")
+        return " ".join(parts)
+
+    def for_document(
+        self,
+        document_id: Optional[str] = None,
+        section_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "WorkflowStepError":
+        """Create a new error with a single document reference added.
+
+        Args:
+            document_id: Document ID to add
+            section_id: Section ID to add
+            **kwargs: Additional WorkflowDocumentRef fields
+
+        Returns:
+            New WorkflowStepError with the document reference appended
+        """
+        new_ref = WorkflowDocumentRef(
+            document_id=document_id,
+            section_id=section_id,
+            **kwargs,
+        )
+        return WorkflowStepError(
+            step=self.step,
+            message=self.message,
+            action=self.action,
+            severity=self.severity,
+            documents=self.documents + (new_ref,),
+            metadata=self.metadata.copy(),
+            cause=self.cause,
+            retryable=self.retryable,
+        )
+
+    def with_documents(self, documents: Tuple[WorkflowDocumentRef, ...]) -> "WorkflowStepError":
+        """Create a new error with the specified documents.
+
+        Args:
+            documents: Tuple of document references to use
+
+        Returns:
+            New WorkflowStepError with the specified documents
+        """
+        return WorkflowStepError(
+            step=self.step,
+            message=self.message,
+            action=self.action,
+            severity=self.severity,
+            documents=documents,
+            metadata=self.metadata.copy(),
+            cause=self.cause,
+            retryable=self.retryable,
+        )
+
+    def root_cause(self) -> Exception:
+        """Get the root cause of this error, traversing the cause chain.
+
+        Returns:
+            The deepest cause in the chain, or self if no cause
+        """
+        current: Exception = self
+        while isinstance(current, WorkflowStepError) and current.cause:
+            current = current.cause
+        return current
+
+    def to_event_payload(self) -> Dict[str, Any]:
+        """Convert to a serializable dict for event emission.
+
+        This drops the .cause (not serializable) and converts dataclasses to dicts.
+
+        Returns:
+            Dictionary suitable for JSON serialization
+        """
+        return {
+            "step": self.step,
+            "message": self.message,
+            "action": self.action,
+            "severity": self.severity,
+            "documents": [doc.to_dict() for doc in self.documents],
+            "metadata": self.metadata,
+            "retryable": self.retryable,
+            "cause_type": type(self.cause).__name__ if self.cause else None,
+            "cause_message": str(self.cause) if self.cause else None,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"WorkflowStepError(step={self.step!r}, message={self.message!r}, "
+            f"action={self.action!r}, severity={self.severity!r}, "
+            f"documents={len(self.documents)}, retryable={self.retryable})"
+        )
+
+
+def record_step_error(
+    error: WorkflowStepError,
+    *,
+    model_name: Optional[str] = None,
+    ctx: Optional["PipelineContext"] = None,
+) -> Dict[str, Any]:
+    """Record a step error to logging and event system.
+
+    This utility function:
+    1. Logs at the appropriate severity level
+    2. Emits a step_error event via the global event emitter
+    3. Returns a dict for inclusion in model results
+
+    Args:
+        error: The WorkflowStepError to record
+        model_name: Optional model name for logger context
+        ctx: Optional PipelineContext for workflow correlation
+
+    Returns:
+        Dict with error recording summary, e.g., {"errors_recorded": 1}
+    """
+    from .dbos_events import get_event_emitter
+
+    # Determine logger name
+    logger_name = f"kurt.core.steps.{model_name}" if model_name else "kurt.core.steps"
+    step_logger = logging.getLogger(logger_name)
+
+    # Log at appropriate level based on severity
+    log_message = f"{error.step}: {error.message}"
+    if error.documents:
+        log_message += f" (affecting {len(error.documents)} documents)"
+
+    if error.severity == "fatal":
+        step_logger.error(log_message, exc_info=error.cause is not None)
+    elif error.severity == "recoverable":
+        step_logger.warning(log_message)
+    else:  # info
+        step_logger.info(log_message)
+
+    # Emit event
+    event_emitter = get_event_emitter()
+    if event_emitter:
+        event_emitter.emit_step_error(
+            model_name=model_name or error.step,
+            error_payload=error.to_event_payload(),
+            workflow_id=ctx.workflow_id if ctx else None,
+        )
+
+    return {
+        "errors_recorded": len(error.documents) if error.documents else 1,
+        "error_step": error.step,
+        "error_action": error.action,
+    }
+
+
+def make_doc_ref(
+    document_id: Optional[str] = None,
+    section_id: Optional[str] = None,
+    source_url: Optional[str] = None,
+    **kwargs: Any,
+) -> WorkflowDocumentRef:
+    """Convenience factory for creating WorkflowDocumentRef instances.
+
+    Args:
+        document_id: Primary document identifier
+        section_id: Section within document
+        source_url: Original source URL
+        **kwargs: Additional fields (cms_document_id, hash, entity_name, claim_hash)
+
+    Returns:
+        WorkflowDocumentRef instance
+    """
+    return WorkflowDocumentRef(
+        document_id=document_id,
+        section_id=section_id,
+        source_url=source_url,
+        **kwargs,
+    )

--- a/src/kurt/core/tests/test_workflow_step_error.py
+++ b/src/kurt/core/tests/test_workflow_step_error.py
@@ -1,0 +1,425 @@
+"""Tests for WorkflowStepError and related utilities."""
+
+import pytest
+
+from kurt.core.dbos_events import DBOSEventEmitter
+from kurt.core.errors import (
+    WorkflowDocumentRef,
+    WorkflowStepError,
+    make_doc_ref,
+    record_step_error,
+)
+
+
+class TestWorkflowDocumentRef:
+    """Tests for WorkflowDocumentRef dataclass."""
+
+    def test_basic_creation(self):
+        """Test creating a document reference with basic fields."""
+        ref = WorkflowDocumentRef(
+            document_id="doc1",
+            section_id="sec1",
+        )
+        assert ref.document_id == "doc1"
+        assert ref.section_id == "sec1"
+        assert ref.source_url is None
+
+    def test_all_fields(self):
+        """Test creating a document reference with all fields."""
+        ref = WorkflowDocumentRef(
+            document_id="doc1",
+            section_id="sec1",
+            source_url="https://example.com/doc1",
+            cms_document_id="cms-123",
+            hash="abc123",
+            entity_name="Python",
+            claim_hash="claim-hash-456",
+        )
+        assert ref.document_id == "doc1"
+        assert ref.source_url == "https://example.com/doc1"
+        assert ref.cms_document_id == "cms-123"
+        assert ref.entity_name == "Python"
+        assert ref.claim_hash == "claim-hash-456"
+
+    def test_to_dict_excludes_none(self):
+        """Test that to_dict excludes None values."""
+        ref = WorkflowDocumentRef(
+            document_id="doc1",
+            section_id=None,
+        )
+        d = ref.to_dict()
+        assert d == {"document_id": "doc1"}
+        assert "section_id" not in d
+
+    def test_str_representation(self):
+        """Test string representation of document reference."""
+        ref = WorkflowDocumentRef(document_id="doc1", section_id="sec1")
+        s = str(ref)
+        assert "doc=doc1" in s
+        assert "sec=sec1" in s
+
+    def test_str_with_entity(self):
+        """Test string representation with entity name."""
+        ref = WorkflowDocumentRef(entity_name="Python")
+        s = str(ref)
+        assert "entity=Python" in s
+
+    def test_empty_ref(self):
+        """Test empty document reference."""
+        ref = WorkflowDocumentRef()
+        assert str(ref) == "DocRef()"
+        assert ref.to_dict() == {}
+
+
+class TestWorkflowStepError:
+    """Tests for WorkflowStepError exception class."""
+
+    def test_basic_creation(self):
+        """Test creating a basic workflow step error."""
+        error = WorkflowStepError(
+            step="indexing.section_extractions",
+            message="LLM rate limit exceeded",
+        )
+        assert error.step == "indexing.section_extractions"
+        assert error.message == "LLM rate limit exceeded"
+        assert error.action == "fail_model"  # default
+        assert error.severity == "fatal"  # default
+        assert error.documents == ()
+        assert error.metadata == {}
+        assert error.cause is None
+        assert error.retryable is False
+
+    def test_skip_record_action(self):
+        """Test error with skip_record action."""
+        docs = (
+            WorkflowDocumentRef(document_id="doc1", section_id="sec1"),
+            WorkflowDocumentRef(document_id="doc1", section_id="sec2"),
+        )
+        error = WorkflowStepError(
+            step="indexing.section_extractions",
+            message="LLM rate limit exceeded",
+            action="skip_record",
+            severity="recoverable",
+            documents=docs,
+            metadata={"llm_model": "claude-3-haiku"},
+            retryable=True,
+        )
+        assert error.action == "skip_record"
+        assert error.severity == "recoverable"
+        assert len(error.documents) == 2
+        assert error.metadata["llm_model"] == "claude-3-haiku"
+        assert error.retryable is True
+
+    def test_exception_message(self):
+        """Test that error message is properly built."""
+        error = WorkflowStepError(
+            step="indexing.section_extractions",
+            message="LLM rate limit exceeded",
+            documents=(WorkflowDocumentRef(document_id="doc1"),),
+        )
+        msg = str(error)
+        assert "[indexing.section_extractions]" in msg
+        assert "LLM rate limit exceeded" in msg
+        assert "1 document affected" in msg
+
+    def test_exception_message_with_cause(self):
+        """Test exception message includes cause."""
+        cause = ValueError("Original error")
+        error = WorkflowStepError(
+            step="test.step",
+            message="Processing failed",
+            cause=cause,
+        )
+        msg = str(error)
+        assert "Caused by: ValueError: Original error" in msg
+
+    def test_for_document_helper(self):
+        """Test for_document helper method."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Error",
+        )
+        new_error = error.for_document(document_id="doc1", section_id="sec1")
+
+        assert len(new_error.documents) == 1
+        assert new_error.documents[0].document_id == "doc1"
+        assert new_error.documents[0].section_id == "sec1"
+        # Original should be unchanged
+        assert len(error.documents) == 0
+
+    def test_for_document_appends(self):
+        """Test for_document appends to existing documents."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Error",
+            documents=(WorkflowDocumentRef(document_id="doc1"),),
+        )
+        new_error = error.for_document(document_id="doc2")
+
+        assert len(new_error.documents) == 2
+        assert new_error.documents[0].document_id == "doc1"
+        assert new_error.documents[1].document_id == "doc2"
+
+    def test_with_documents_helper(self):
+        """Test with_documents helper method."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Error",
+            documents=(WorkflowDocumentRef(document_id="doc1"),),
+        )
+        new_docs = (
+            WorkflowDocumentRef(document_id="doc2"),
+            WorkflowDocumentRef(document_id="doc3"),
+        )
+        new_error = error.with_documents(new_docs)
+
+        assert len(new_error.documents) == 2
+        assert new_error.documents[0].document_id == "doc2"
+        assert new_error.documents[1].document_id == "doc3"
+
+    def test_root_cause(self):
+        """Test root_cause traverses cause chain."""
+        original = ValueError("Original")
+        wrapped = WorkflowStepError(
+            step="step1",
+            message="Wrapper 1",
+            cause=original,
+        )
+        outer = WorkflowStepError(
+            step="step2",
+            message="Wrapper 2",
+            cause=wrapped,
+        )
+
+        root = outer.root_cause()
+        assert root is original
+
+    def test_root_cause_no_chain(self):
+        """Test root_cause with no cause returns self."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Error",
+        )
+        assert error.root_cause() is error
+
+    def test_to_event_payload(self):
+        """Test conversion to event payload."""
+        cause = ValueError("Test error")
+        error = WorkflowStepError(
+            step="indexing.section_extractions",
+            message="LLM rate limit exceeded",
+            action="skip_record",
+            severity="recoverable",
+            documents=(WorkflowDocumentRef(document_id="doc1", section_id="sec1"),),
+            metadata={"llm_model": "claude-3-haiku"},
+            cause=cause,
+            retryable=True,
+        )
+
+        payload = error.to_event_payload()
+
+        assert payload["step"] == "indexing.section_extractions"
+        assert payload["message"] == "LLM rate limit exceeded"
+        assert payload["action"] == "skip_record"
+        assert payload["severity"] == "recoverable"
+        assert len(payload["documents"]) == 1
+        assert payload["documents"][0]["document_id"] == "doc1"
+        assert payload["metadata"]["llm_model"] == "claude-3-haiku"
+        assert payload["retryable"] is True
+        assert payload["cause_type"] == "ValueError"
+        assert payload["cause_message"] == "Test error"
+
+    def test_to_event_payload_no_cause(self):
+        """Test event payload without cause."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Error",
+        )
+        payload = error.to_event_payload()
+        assert payload["cause_type"] is None
+        assert payload["cause_message"] is None
+
+    def test_repr(self):
+        """Test repr representation."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Error",
+            documents=(WorkflowDocumentRef(document_id="doc1"),),
+        )
+        r = repr(error)
+        assert "WorkflowStepError" in r
+        assert "test.step" in r
+        assert "documents=1" in r
+
+
+class TestMakeDocRef:
+    """Tests for make_doc_ref helper function."""
+
+    def test_basic_usage(self):
+        """Test basic make_doc_ref usage."""
+        ref = make_doc_ref(document_id="doc1", section_id="sec1")
+        assert isinstance(ref, WorkflowDocumentRef)
+        assert ref.document_id == "doc1"
+        assert ref.section_id == "sec1"
+
+    def test_with_kwargs(self):
+        """Test make_doc_ref with extra kwargs."""
+        ref = make_doc_ref(
+            document_id="doc1",
+            entity_name="Python",
+            claim_hash="abc123",
+        )
+        assert ref.entity_name == "Python"
+        assert ref.claim_hash == "abc123"
+
+
+class TestRecordStepError:
+    """Tests for record_step_error utility function."""
+
+    def test_basic_recording(self):
+        """Test basic error recording."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Test error",
+            documents=(WorkflowDocumentRef(document_id="doc1"),),
+        )
+
+        result = record_step_error(error, model_name="test.model")
+
+        assert result["errors_recorded"] == 1
+        assert result["error_step"] == "test.step"
+        assert result["error_action"] == "fail_model"
+
+    def test_recording_without_documents(self):
+        """Test error recording without documents defaults to 1."""
+        error = WorkflowStepError(
+            step="test.step",
+            message="Test error",
+        )
+
+        result = record_step_error(error)
+        assert result["errors_recorded"] == 1
+
+    def test_emit_step_error_integration(self):
+        """Test that record_step_error emits to event emitter."""
+        from kurt.core.dbos_events import configure_event_emitter, get_event_emitter
+
+        # Configure a fresh emitter for this test
+        configure_event_emitter(workflow_id="test_wf")
+        emitter = get_event_emitter()
+        emitter.clear_events()
+
+        error = WorkflowStepError(
+            step="test.step",
+            message="Test error",
+            action="skip_record",
+            severity="recoverable",
+            documents=(WorkflowDocumentRef(document_id="doc1"),),
+        )
+
+        record_step_error(error, model_name="test.model")
+
+        events = emitter.get_events()
+        assert len(events) == 1
+        event = events[0]
+        assert event.event_type == "step_error"
+        assert event.model_name == "test.model"
+        assert event.payload["step"] == "test.step"
+        assert event.payload["message"] == "Test error"
+
+
+class TestDBOSEventEmitterStepError:
+    """Tests for emit_step_error in DBOSEventEmitter."""
+
+    def test_emit_step_error(self):
+        """Test emitting step error event."""
+        emitter = DBOSEventEmitter(workflow_id="wf1")
+
+        error_payload = {
+            "step": "indexing.section_extractions",
+            "message": "LLM rate limit exceeded",
+            "action": "skip_record",
+            "severity": "recoverable",
+            "documents": [{"document_id": "doc1", "section_id": "sec1"}],
+            "metadata": {"llm_model": "claude-3-haiku"},
+            "retryable": True,
+        }
+
+        emitter.emit_step_error("test.model", error_payload)
+
+        events = emitter.get_events()
+        assert len(events) == 1
+        event = events[0]
+        assert event.event_type == "step_error"
+        assert event.model_name == "test.model"
+        assert event.workflow_id == "wf1"
+        assert event.payload == error_payload
+        assert event.error == "LLM rate limit exceeded"
+
+    def test_emit_step_error_with_override_workflow(self):
+        """Test step error with workflow ID override."""
+        emitter = DBOSEventEmitter(workflow_id="wf1")
+
+        error_payload = {"step": "test", "message": "Error"}
+        emitter.emit_step_error("test.model", error_payload, workflow_id="override_wf")
+
+        events = emitter.get_events()
+        assert events[0].workflow_id == "override_wf"
+
+
+class TestWorkflowStepErrorIntegration:
+    """Integration tests for WorkflowStepError with pipeline components."""
+
+    def test_error_can_be_raised_and_caught(self):
+        """Test that WorkflowStepError can be raised and caught."""
+        with pytest.raises(WorkflowStepError) as exc_info:
+            raise WorkflowStepError(
+                step="test.step",
+                message="Test error",
+                action="fail_model",
+            )
+
+        error = exc_info.value
+        assert error.step == "test.step"
+        assert error.action == "fail_model"
+
+    def test_error_with_skip_record_payload(self):
+        """Test creating error payload for skip_record scenario."""
+        error = WorkflowStepError(
+            step="indexing.section_extractions",
+            message="OpenAI 429 rate limit",
+            action="skip_record",
+            severity="recoverable",
+            documents=(
+                WorkflowDocumentRef(document_id="doc1", section_id="sec1"),
+                WorkflowDocumentRef(document_id="doc1", section_id="sec2"),
+            ),
+            metadata={"llm_model": "gpt-4", "retry_after": 60},
+            retryable=True,
+        )
+
+        # Verify the payload can be serialized
+        payload = error.to_event_payload()
+        assert isinstance(payload, dict)
+        assert len(payload["documents"]) == 2
+        assert all(isinstance(d, dict) for d in payload["documents"])
+
+    def test_error_with_fail_model_for_db_constraint(self):
+        """Test creating error for database constraint violation."""
+        db_error = Exception("UNIQUE constraint failed: entities.name")
+        error = WorkflowStepError(
+            step="indexing.entity_resolution",
+            message="Database constraint violation",
+            action="fail_model",
+            severity="fatal",
+            documents=(WorkflowDocumentRef(entity_name="Python"),),
+            cause=db_error,
+        )
+
+        assert error.action == "fail_model"
+        assert error.severity == "fatal"
+        assert error.root_cause() is db_error
+
+        payload = error.to_event_payload()
+        assert payload["cause_type"] == "Exception"
+        assert "UNIQUE constraint" in payload["cause_message"]

--- a/src/kurt/core/workflow.py
+++ b/src/kurt/core/workflow.py
@@ -115,6 +115,8 @@ async def run_workflow(
         }
     )
 
+    # errors may be strings (legacy) or dicts (serialized WorkflowStepError)
+    # CLI parsing should tolerate both formats
     return {
         "workflow_id": workflow_id,
         "pipeline": pipeline.name,


### PR DESCRIPTION
## Summary

- Add `WorkflowStepError` exception and `WorkflowDocumentRef` dataclass in new `errors.py` module
- Integrate structured error handling in all four indexing steps with appropriate actions:
  - `skip_record` for recoverable errors (LLM failures, parsing errors)
  - `fail_model` for systemic errors (DB constraint violations)
- Add `emit_step_error()` to DBOSEventEmitter for error event emission
- Add comprehensive test coverage (35 tests passing)

## Test plan

- [x] Run `pytest src/kurt/core/tests/test_workflow_step_error.py` - 28 tests pass
- [x] Run `pytest src/kurt/core/tests/test_run_pipeline.py` - 7 tests pass
- [x] Verify linting passes with ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)